### PR TITLE
A refactor into a separate single script file

### DIFF
--- a/Go3CB
+++ b/Go3CB
@@ -1,5 +1,7 @@
 #!/bin/bash
 #
+# Tomasz Bednarz, 2023
+# based on work by
 # Lionel Cordesses, 2023.
 # Script to build a MAME or FBAlpha romset (extension: .zip_original), and also FBNeo romset (extension: .zip) for 3 Count Bout from the Amazon Prime Gaming game.
 

--- a/Go3CB
+++ b/Go3CB
@@ -1,0 +1,64 @@
+#!/bin/bash
+#
+# Lionel Cordesses, 2023.
+# Script to build a MAME or FBAlpha romset (extension: .zip_original), and also FBNeo romset (extension: .zip) for 3 Count Bout from the Amazon Prime Gaming game.
+
+. ./romExtractionTools.sh
+
+#=========================================================
+MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/3 Count Bout/Data/rom"
+#=========================================================
+# MY_OUT_ROM_DIR_1 is the temporary output directory for ncommand
+MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_3countb"
+#=========================================================
+MY_ZIP_NAME="3countb"
+ROM_ID="043"
+#++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+# Do not edit the path below this line!
+#
+MY_OUT_ROM_DIR="$MY_OUT_ROM_DIR_1"/"$MY_ZIP_NAME"
+
+checkForZip
+checkForCompiledSwizzle
+cleanFilesForReRun $MY_OUT_ROM_DIR $MY_ZIP_NAME
+
+# Check if s2.bin is available, and copy it as 096-s1.s1.
+if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then
+    echo "File s2.bin not found in $MY_RAW_ROMS_DIR!"
+fi
+
+cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/"$ROM_ID"-s1.s1
+
+
+# Sound data
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v1.v1 skip=0 count=$((0x200000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v2.v2 skip=$((0x200000)) count=$((0x200000)) iflag=$IFLAG
+
+# Z80 code
+dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1 skip=$((0x0)) count=$((0x020000)) iflag=$IFLAG
+
+# 68K code
+# Note: the 096-p1.p1 CRC32 is wrong. It is the same issue that I encountered with Ninja Commando and Ghost Pilots.
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 skip=$((0x0)) count=$((0x100000)) iflag=$IFLAG
+
+# Sprites
+# It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2
+./ss_unswizzle "$MY_RAW_ROMS_DIR"/c1.bin odd even
+split -b 2097152 even even_d
+split -b 2097152 odd odd_d
+
+mv even_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c2.c2
+mv even_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c4.c4
+
+mv odd_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c1.c1
+mv odd_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c3.c3
+
+rm even odd
+
+# To make these work I had to convert them again with RomBuild v.0.8 NeoGeo Special: http://www.logiqx.com/Tools/ROMBuild/
+
+# Modification of the 68K file to comply with FBNeo CRC32: replace byte at address 0x115 (value = 02) by (value = 00).
+#printf '\x00' | dd of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
+
+zip -j -r "$MY_ZIP_NAME".zip "$MY_OUT_ROM_DIR"
+

--- a/Go3CB
+++ b/Go3CB
@@ -8,10 +8,10 @@
 . ./romExtractionTools.sh
 
 #=========================================================
-MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/3 Count Bout/Data/rom"
+MY_RAW_ROMS_DIR="$AMAZONGAMEFOLDER"/"3 Count Bout/Data/rom"
 #=========================================================
 # MY_OUT_ROM_DIR_1 is the temporary output directory for ncommand
-MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_3countb"
+MY_OUT_ROM_DIR_1="$ROMOUTPUTFOLDER"
 #=========================================================
 MY_ZIP_NAME="3countb"
 ROM_ID="043"

--- a/Go3CB
+++ b/Go3CB
@@ -44,17 +44,23 @@ dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 skip=$((0x0
 # Sprites
 # It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2
 ./ss_unswizzle "$MY_RAW_ROMS_DIR"/c1.bin odd even
-split -b 2097152 even even_d
-split -b 2097152 odd odd_d
 
-mv even_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c2.c2
-mv even_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c4.c4
+( dd if=even skip=$((0x0)) count=$((0x100000)) iflag=skip_bytes,count_bytes
+    dd if=even skip=$((0x200000)) count=$((0x100000)) iflag=skip_bytes,count_bytes
+) > "$MY_OUT_ROM_DIR"/"$ROM_ID"-c2.c2
 
-mv odd_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c1.c1
-mv odd_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c3.c3
+( dd if=odd skip=$((0x0)) count=$((0x100000)) iflag=skip_bytes,count_bytes
+    dd if=odd skip=$((0x200000)) count=$((0x100000)) iflag=skip_bytes,count_bytes
+) > "$MY_OUT_ROM_DIR"/"$ROM_ID"-c1.c1
+
+( dd if=even skip=$((0x100000)) count=$((0x100000)) iflag=skip_bytes,count_bytes
+    dd if=even skip=$((0x300000)) count=$((0x100000)) iflag=skip_bytes,count_bytes
+) > "$MY_OUT_ROM_DIR"/"$ROM_ID"-c4.c4
+
+( dd if=odd skip=$((0x100000)) count=$((0x100000)) iflag=skip_bytes,count_bytes
+    dd if=odd skip=$((0x300000)) count=$((0x100000)) iflag=skip_bytes,count_bytes
+) > "$MY_OUT_ROM_DIR"/"$ROM_ID"-c3.c3
 
 rm even odd
-
-# To make these work post mame 0.80, I had to convert the C files again with RomBuild v.0.8 NeoGeo Special: http://www.logiqx.com/Tools/ROMBuild/
 
 zip -j -r "$MY_ZIP_NAME".zip "$MY_OUT_ROM_DIR"

--- a/Go3CB
+++ b/Go3CB
@@ -28,9 +28,7 @@ cleanFilesForReRun $MY_OUT_ROM_DIR $MY_ZIP_NAME
 if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then
     echo "File s2.bin not found in $MY_RAW_ROMS_DIR!"
 fi
-
 cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/"$ROM_ID"-s1.s1
-
 
 # Sound data
 dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v1.v1 skip=0 count=$((0x200000)) iflag=$IFLAG
@@ -57,10 +55,6 @@ mv odd_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c3.c3
 
 rm even odd
 
-# To make these work I had to convert them again with RomBuild v.0.8 NeoGeo Special: http://www.logiqx.com/Tools/ROMBuild/
-
-# Modification of the 68K file to comply with FBNeo CRC32: replace byte at address 0x115 (value = 02) by (value = 00).
-#printf '\x00' | dd of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
+# To make these work post mame 0.80, I had to convert the C files again with RomBuild v.0.8 NeoGeo Special: http://www.logiqx.com/Tools/ROMBuild/
 
 zip -j -r "$MY_ZIP_NAME".zip "$MY_OUT_ROM_DIR"
-

--- a/GoAM2
+++ b/GoAM2
@@ -49,6 +49,8 @@ rm tmp0xFF.bin
 # Note: the 096-p1.p1 CRC32 is wrong. It is the same issue that I encountered with Ninja Commando and Ghost Pilots.
 dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 skip=$((0x0)) count=$((0x80000)) iflag=$IFLAG
 dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p2.p2 skip=$((0x80000)) count=$((0x20000)) iflag=$IFLAG
+# Modification of the 68K file to comply with FBNeo CRC32: replace byte at address 0x115 (value = 02) by (value = 00).
+printf '\x00' | dd of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
 
 # Sprites
 # It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2
@@ -64,10 +66,4 @@ mv odd_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c3.c3
 
 rm even odd
 
-zip -j -r aof3.zip_original "$MY_OUT_ROM_DIR"
-
-# Modification of the 68K file to comply with FBNeo CRC32: replace byte at address 0x115 (value = 02) by (value = 00).
-printf '\x00' | dd of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
-
 zip -j -r "$MY_ZIP_NAME".zip "$MY_OUT_ROM_DIR"
-

--- a/GoAM2
+++ b/GoAM2
@@ -1,0 +1,71 @@
+#!/bin/bash
+#
+# Lionel Cordesses, 2023.
+# Script to build a MAME or FBAlpha romset (extension: .zip_original), and also FBNeo romset (extension: .zip) for Alpha Mission II from the Amazon Prime Gaming game.
+
+. ./romExtractionTools.sh
+
+#=========================================================
+MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Alpha Mission II/Data/rom"
+#=========================================================
+# MY_OUT_ROM_DIR_1 is the temporary output directory for ncommand
+MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_alpham2"
+#=========================================================
+MY_ZIP_NAME=alpham2
+ROM_ID="007"
+#++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+# Do not edit the path below this line!
+#
+MY_OUT_ROM_DIR="$MY_OUT_ROM_DIR_1"/"$MY_ZIP_NAME"
+
+checkForZip
+checkForCompiledSwizzle
+cleanFilesForReRun $MY_OUT_ROM_DIR $MY_ZIP_NAME
+
+# Check if s2.bin is available, and copy it as 096-s1.s1.
+if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then
+    echo "File s2.bin not found in $MY_RAW_ROMS_DIR!"
+fi
+
+cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/"$ROM_ID"-s1.s1
+
+
+# Sound data
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v1.v1 skip=0 count=$((0x100000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v2.v2 skip=$((0x100000)) count=$((0x100000)) iflag=$IFLAG
+
+# Z80 code
+dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1b skip=$((0x0)) count=$((0x010000)) iflag=$IFLAG
+# Create the 64KB of 0xff
+dd if=/dev/zero ibs=1k count=64 | tr "\000" "\377" >tmp0xFF.bin
+# Concat 050-m1.m1 and tmp0xFF.bin to create the final 050-m1.m1.
+cat "$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1b tmp0xFF.bin >"$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1
+rm "$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1b
+rm tmp0xFF.bin
+
+# 68K code
+# Note: the 096-p1.p1 CRC32 is wrong. It is the same issue that I encountered with Ninja Commando and Ghost Pilots.
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 skip=$((0x0)) count=$((0x80000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p2.p2 skip=$((0x80000)) count=$((0x20000)) iflag=$IFLAG
+
+# Sprites
+# It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2
+./ss_unswizzle "$MY_RAW_ROMS_DIR"/c1.bin odd even
+split -b 1048576 even even_d
+split -b 1048576 odd odd_d
+
+mv even_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c2.c2
+mv even_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c4.c4
+
+mv odd_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c1.c1
+mv odd_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c3.c3
+
+rm even odd
+
+zip -j -r aof3.zip_original "$MY_OUT_ROM_DIR"
+
+# Modification of the 68K file to comply with FBNeo CRC32: replace byte at address 0x115 (value = 02) by (value = 00).
+printf '\x00' | dd of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
+
+zip -j -r "$MY_ZIP_NAME".zip "$MY_OUT_ROM_DIR"
+

--- a/GoAM2
+++ b/GoAM2
@@ -1,5 +1,7 @@
 #!/bin/bash
 #
+# Tomasz Bednarz, 2023
+# based on work by
 # Lionel Cordesses, 2023.
 # Script to build a MAME or FBAlpha romset (extension: .zip_original), and also FBNeo romset (extension: .zip) for Alpha Mission II from the Amazon Prime Gaming game.
 

--- a/GoAM2
+++ b/GoAM2
@@ -8,10 +8,10 @@
 . ./romExtractionTools.sh
 
 #=========================================================
-MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Alpha Mission II/Data/rom"
+MY_RAW_ROMS_DIR="$AMAZONGAMEFOLDER"/"Alpha Mission II/Data/rom"
 #=========================================================
 # MY_OUT_ROM_DIR_1 is the temporary output directory for ncommand
-MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_alpham2"
+MY_OUT_ROM_DIR_1="$ROMOUTPUTFOLDER"
 #=========================================================
 MY_ZIP_NAME=alpham2
 ROM_ID="007"

--- a/GoKOF97
+++ b/GoKOF97
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Luca Dal Molin, 2023
+# based on the work of
+# Lionel Cordesses, 2023.
+# Script to build a MAME or FBAlpha romset and also FBNeo romset (extension: .zip) for The King of Fighters '97, from the Amazon Prime Gaming game.
+
+#=========================================================
+MY_RAW_ROMS_DIR="/home/dalmo/Documenti/goNCommand-main/romKOF97"
+#=========================================================
+# MY_OUT_ROM_DIR_1 is the temporary output directory for ninjamas
+MY_OUT_ROM_DIR_1="/home/dalmo/Documenti/goNCommand-main/tmp/"
+#=========================================================
+MY_ZIP_NAME=kof97
+ROM_ID="232"
+#++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+# Do not edit the path below this line!
+#
+MY_OUT_ROM_DIR="$MY_OUT_ROM_DIR_1"/"$MY_ZIP_NAME"
+
+checkForZip
+checkForCompiledSwizzle
+cleanFilesForReRun $MY_OUT_ROM_DIR $MY_ZIP_NAME
+
+# Check if s2.bin is available, and copy it as 232-s1.s1.
+if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then
+    echo "File s2.bin not found in $MY_RAW_ROMS_DIR!"
+fi
+
+cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/232-s1.s1
+
+
+# Sound data
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/232-v1.v1 skip=0 count=$((0x400000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/232-v2.v2 skip=$((0x400000)) count=$((0x400000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/232-v3.v3 skip=$((0x800000)) count=$((0x400000)) iflag=skip_bytes,count_bytes
+
+
+# Z80 code
+cp "$MY_RAW_ROMS_DIR"/m1.bin "$MY_OUT_ROM_DIR"/232-m1.m1
+
+# 68K code
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/232-p1.p1 skip=$((0x0)) count=$((0x100000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/232-p2.sp2 skip=$((0x100000)) count=$((0x400000)) iflag=skip_bytes,count_bytes
+
+# Sprites
+# It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2
+./ss_unswizzle "$MY_RAW_ROMS_DIR"/c1.bin odd even
+split -b 4194304 even even_d
+split -b 4194304 odd odd_d
+
+mv even_daa "$MY_OUT_ROM_DIR"/232-c2.c2
+dd if=even_dab of="$MY_OUT_ROM_DIR"/232-c2.c2 iflag=skip_bytes,count_bytes oflag=append conv=notrunc
+mv even_dac "$MY_OUT_ROM_DIR"/232-c4.c4
+dd if=even_dad of="$MY_OUT_ROM_DIR"/232-c4.c4 iflag=skip_bytes,count_bytes oflag=append conv=notrunc
+mv even_dae "$MY_OUT_ROM_DIR"/232-c6.c6
+
+mv odd_daa "$MY_OUT_ROM_DIR"/232-c1.c1
+dd if=odd_dab of="$MY_OUT_ROM_DIR"/232-c1.c1 iflag=skip_bytes,count_bytes oflag=append conv=notrunc
+mv odd_dac "$MY_OUT_ROM_DIR"/232-c3.c3
+dd if=odd_dad of="$MY_OUT_ROM_DIR"/232-c3.c3 iflag=skip_bytes,count_bytes oflag=append conv=notrunc
+mv odd_dae "$MY_OUT_ROM_DIR"/232-c5.c5
+
+rm even odd even_da* odd_da*
+
+zip -j -r "$MY_ZIP_NAME".zip "$MY_OUT_ROM_DIR"

--- a/GoKOF97
+++ b/GoKOF97
@@ -5,10 +5,10 @@
 # Script to build a MAME or FBAlpha romset and also FBNeo romset (extension: .zip) for The King of Fighters '97, from the Amazon Prime Gaming game.
 
 #=========================================================
-MY_RAW_ROMS_DIR="/home/dalmo/Documenti/goNCommand-main/romKOF97"
+MY_RAW_ROMS_DIR="$AMAZONGAMEFOLDER"/"The King of Fighters 97/Data/rom"
 #=========================================================
 # MY_OUT_ROM_DIR_1 is the temporary output directory for ninjamas
-MY_OUT_ROM_DIR_1="/home/dalmo/Documenti/goNCommand-main/tmp/"
+MY_OUT_ROM_DIR_1="$ROMOUTPUTFOLDER"
 #=========================================================
 MY_ZIP_NAME=kof97
 ROM_ID="232"

--- a/GoMutNat
+++ b/GoMutNat
@@ -8,10 +8,10 @@
 . ./romExtractionTools.sh
 
 #=========================================================
-MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Mutation Nation/Data/rom"
+MY_RAW_ROMS_DIR="$AMAZONGAMEFOLDER"/"Mutation Nation/Data/rom"
 #=========================================================
 # MY_OUT_ROM_DIR_1 is the temporary output directory for ncommand
-MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_mutnat"
+MY_OUT_ROM_DIR_1="$ROMOUTPUTFOLDER"
 #=========================================================
 MY_ZIP_NAME="mutnat"
 ROM_ID="014"

--- a/GoMutNat
+++ b/GoMutNat
@@ -1,0 +1,58 @@
+#!/bin/bash
+#
+# Tomasz Bednarz, 2023
+# based on work by
+# Lionel Cordesses, 2023.
+# Script to build a MAME or FBAlpha romset (extension: .zip_original), and also FBNeo romset (extension: .zip) for Mutant Nation from the Amazon Prime Gaming game.
+
+. ./romExtractionTools.sh
+
+#=========================================================
+MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Mutation Nation/Data/rom"
+#=========================================================
+# MY_OUT_ROM_DIR_1 is the temporary output directory for ncommand
+MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_mutnat"
+#=========================================================
+MY_ZIP_NAME="mutnat"
+ROM_ID="014"
+#++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+# Do not edit the path below this line!
+#
+MY_OUT_ROM_DIR="$MY_OUT_ROM_DIR_1"/"$MY_ZIP_NAME"
+
+checkForZip
+checkForCompiledSwizzle
+cleanFilesForReRun $MY_OUT_ROM_DIR $MY_ZIP_NAME
+
+# Check if s2.bin is available, and copy it as 014-s1.s1.
+if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then
+    echo "File s2.bin not found in $MY_RAW_ROMS_DIR!"
+fi
+cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/"$ROM_ID"-s1.s1
+
+# Sound data
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v1.v1 skip=0 count=$((0x100000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v2.v2 skip=$((0x100000)) count=$((0x100000)) iflag=$IFLAG
+
+# Z80 code
+dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1 skip=$((0x0)) count=$((0x020000)) iflag=$IFLAG
+
+# 68K code
+# Note: the 014-p1.p1 CRC32 is wrong. It is the same issue that I encountered with Ninja Commando and Ghost Pilots.
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 skip=$((0x0)) count=$((0x80000)) iflag=$IFLAG
+
+# Sprites
+# It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2
+./ss_unswizzle "$MY_RAW_ROMS_DIR"/c1.bin odd even
+split -b 1048576 even even_d
+split -b 1048576 odd odd_d
+
+mv even_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c2.c2
+mv even_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c4.c4
+
+mv odd_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c1.c1
+mv odd_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c3.c3
+
+rm even odd
+
+zip -j -r "$MY_ZIP_NAME".zip "$MY_OUT_ROM_DIR"

--- a/GoOT
+++ b/GoOT
@@ -8,10 +8,10 @@
 . ./romExtractionTools.sh
 
 #=========================================================
-MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Over Top/Data/rom"
+MY_RAW_ROMS_DIR="$AMAZONGAMEFOLDER"/"Over Top/Data/rom"
 #=========================================================
 # MY_OUT_ROM_DIR_1 is the temporary output directory for ncommand
-MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_overtop"
+MY_OUT_ROM_DIR_1="$ROMOUTPUTFOLDER"
 #=========================================================
 MY_ZIP_NAME="overtop"
 ROM_ID="212"

--- a/GoOT
+++ b/GoOT
@@ -1,0 +1,66 @@
+#!/bin/bash
+#
+# Tomasz Bednarz, 2023
+# based on work by
+# Lionel Cordesses, 2023.
+# Script to build a MAME or FBAlpha romset (extension: .zip_original), and also FBNeo romset (extension: .zip) for Over Top from the Amazon Prime Gaming game.
+
+. ./romExtractionTools.sh
+
+#=========================================================
+MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Over Top/Data/rom"
+#=========================================================
+# MY_OUT_ROM_DIR_1 is the temporary output directory for ncommand
+MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_overtop"
+#=========================================================
+MY_ZIP_NAME="overtop"
+ROM_ID="212"
+#++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+# Do not edit the path below this line!
+#
+MY_OUT_ROM_DIR="$MY_OUT_ROM_DIR_1"/"$MY_ZIP_NAME"
+
+checkForZip
+checkForCompiledSwizzle
+cleanFilesForReRun $MY_OUT_ROM_DIR $MY_ZIP_NAME
+
+# Check if s2.bin is available, and copy it as 096-s1.s1.
+if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then
+    echo "File s2.bin not found in $MY_RAW_ROMS_DIR!"
+fi
+cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/"$ROM_ID"-s1.s1
+
+# Sound data
+cp "$MY_RAW_ROMS_DIR"/v1.bin "$MY_OUT_ROM_DIR"/"$ROM_ID"-v1.v1
+
+# Z80 code
+#dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1 skip=$((0x0)) count=$((0x020000)) iflag=$IFLAG
+(
+    dd if="$MY_RAW_ROMS_DIR"/m1.bin skip=0 count=$((0x10000)) iflag=$IFLAG
+    dd if="$MY_RAW_ROMS_DIR"/m1.bin skip=$((0x20000)) count=$((0x10000)) iflag=$IFLAG
+) > "$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1
+
+# 68K code
+#dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 skip=$((0x0)) count=$((0x200000)) iflag=$IFLAG
+(
+    dd if="$MY_RAW_ROMS_DIR"/p1.bin skip=$((0x100000)) count=$((0x100000)) iflag=$IFLAG
+    dd if="$MY_RAW_ROMS_DIR"/p1.bin skip=0 count=$((0x100000)) iflag=$IFLAG
+) > "$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1
+
+# Sprites
+# It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2
+./ss_unswizzle "$MY_RAW_ROMS_DIR"/c1.bin odd even
+split -b 4194304 even even_d
+split -b 4194304 odd odd_d
+
+mv even_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c2.c2
+mv even_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c4.c4
+mv even_dac "$MY_OUT_ROM_DIR"/"$ROM_ID"-c6.c6
+
+mv odd_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c1.c1
+mv odd_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c3.c3
+mv odd_dac "$MY_OUT_ROM_DIR"/"$ROM_ID"-c5.c5
+
+rm even odd
+
+zip -j -r "$MY_ZIP_NAME".zip "$MY_OUT_ROM_DIR"

--- a/GoSB
+++ b/GoSB
@@ -1,0 +1,57 @@
+#!/bin/bash
+#
+# Tomasz Bednarz, 2023
+# based on work by
+# Lionel Cordesses, 2023.
+# Script to build a MAME or FBAlpha romset (extension: .zip_original), and also FBNeo romset (extension: .zip) for Soccer Brawl from the Amazon Prime Gaming game.
+
+. ./romExtractionTools.sh
+
+#=========================================================
+MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Soccer Brawl/Data/rom"
+#=========================================================
+# MY_OUT_ROM_DIR_1 is the temporary output directory for ncommand
+MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_socbrawl"
+#=========================================================
+MY_ZIP_NAME="socbrawl"
+ROM_ID="031"
+#++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+# Do not edit the path below this line!
+#
+MY_OUT_ROM_DIR="$MY_OUT_ROM_DIR_1"/"$MY_ZIP_NAME"
+
+checkForZip
+checkForCompiledSwizzle
+cleanFilesForReRun $MY_OUT_ROM_DIR $MY_ZIP_NAME
+
+# Check if s2.bin is available, and copy it as 096-s1.s1.
+if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then
+    echo "File s2.bin not found in $MY_RAW_ROMS_DIR!"
+fi
+cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/"$ROM_ID"-s1.s1
+
+# Sound data
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v1.v1 skip=0 count=$((0x100000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v2.v2 skip=$((0x100000)) count=$((0x100000)) iflag=$IFLAG
+
+# Z80 code
+dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1 skip=$((0x0)) count=$((0x020000)) iflag=$IFLAG
+
+# 68K code
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-pg1.p1 skip=$((0x0)) count=$((0x80000)) iflag=$IFLAG
+
+# Sprites
+# It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2
+./ss_unswizzle "$MY_RAW_ROMS_DIR"/c1.bin odd even
+split -b 1048576 even even_d
+split -b 1048576 odd odd_d
+
+mv even_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c2.c2
+mv even_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c4.c4
+
+mv odd_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c1.c1
+mv odd_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c3.c3
+
+rm even odd
+
+zip -j -r "$MY_ZIP_NAME".zip "$MY_OUT_ROM_DIR"

--- a/GoSB
+++ b/GoSB
@@ -8,10 +8,10 @@
 . ./romExtractionTools.sh
 
 #=========================================================
-MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Soccer Brawl/Data/rom"
+MY_RAW_ROMS_DIR="$AMAZONGAMEFOLDER"/"Soccer Brawl/Data/rom"
 #=========================================================
 # MY_OUT_ROM_DIR_1 is the temporary output directory for ncommand
-MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_socbrawl"
+MY_OUT_ROM_DIR_1="$ROMOUTPUTFOLDER"
 #=========================================================
 MY_ZIP_NAME="socbrawl"
 ROM_ID="031"

--- a/GoSSpy
+++ b/GoSSpy
@@ -8,10 +8,10 @@
 . ./romExtractionTools.sh
 
 #=========================================================
-MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/The Super Spy/Data/rom"
+MY_RAW_ROMS_DIR="$AMAZONGAMEFOLDER"/"The Super Spy/Data/rom"
 #=========================================================
 # MY_OUT_ROM_DIR_1 is the temporary output directory for ncommand
-MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_superspy"
+MY_OUT_ROM_DIR_1="$ROMOUTPUTFOLDER"
 #=========================================================
 MY_ZIP_NAME="superspy"
 ROM_ID="011"

--- a/GoSSpy
+++ b/GoSSpy
@@ -40,7 +40,7 @@ dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1 skip=$((0x0
 
 # 68K code
 dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 skip=$((0x0)) count=$((0x80000)) iflag=$IFLAG
-dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-sp.p2 skip=$((0x80000)) count=$((0x20000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/sp.p2 skip=$((0x80000)) count=$((0x20000)) iflag=$IFLAG
 
 # Sprites
 # It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2

--- a/GoSSpy
+++ b/GoSSpy
@@ -1,0 +1,59 @@
+#!/bin/bash
+#
+# Tomasz Bednarz, 2023
+# based on work by
+# Lionel Cordesses, 2023.
+# Script to build a MAME or FBAlpha romset (extension: .zip_original), and also FBNeo romset (extension: .zip) for The Super Spy from the Amazon Prime Gaming game.
+
+. ./romExtractionTools.sh
+
+#=========================================================
+MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/The Super Spy/Data/rom"
+#=========================================================
+# MY_OUT_ROM_DIR_1 is the temporary output directory for ncommand
+MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_superspy"
+#=========================================================
+MY_ZIP_NAME="superspy"
+ROM_ID="011"
+#++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+# Do not edit the path below this line!
+#
+MY_OUT_ROM_DIR="$MY_OUT_ROM_DIR_1"/"$MY_ZIP_NAME"
+
+checkForZip
+checkForCompiledSwizzle
+cleanFilesForReRun $MY_OUT_ROM_DIR $MY_ZIP_NAME
+
+# Check if s2.bin is available, and copy it as 096-s1.s1.
+if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then
+    echo "File s2.bin not found in $MY_RAW_ROMS_DIR!"
+fi
+cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/"$ROM_ID"-s1.s1
+
+# Sound data
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v11.v11 skip=$((0x0)) count=$((0x100000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v12.v12 skip=$((0x100000)) count=$((0x080000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v21.v21 skip=$((0x180000)) count=$((0x080000)) iflag=$IFLAG
+
+# Z80 code
+dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1 skip=$((0x0)) count=$((0x040000)) iflag=$IFLAG
+
+# 68K code
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 skip=$((0x0)) count=$((0x80000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-sp.p2 skip=$((0x80000)) count=$((0x20000)) iflag=$IFLAG
+
+# Sprites
+# It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2
+./ss_unswizzle "$MY_RAW_ROMS_DIR"/c1.bin odd even
+split -b 1048576 even even_d
+split -b 1048576 odd odd_d
+
+mv even_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c2.c2
+mv even_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c4.c4
+
+mv odd_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c1.c1
+mv odd_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c3.c3
+
+rm even odd
+
+zip -j -r "$MY_ZIP_NAME".zip "$MY_OUT_ROM_DIR"

--- a/GoSengoku2
+++ b/GoSengoku2
@@ -1,0 +1,61 @@
+#!/bin/bash
+#
+# Tomasz Bednarz, 2023
+# based on work by
+# Lionel Cordesses, 2023.
+# Script to build a MAME or FBAlpha romset (extension: .zip_original), and also FBNeo romset (extension: .zip) for Sengoku 2 from the Amazon Prime Gaming game.
+
+. ./romExtractionTools.sh
+
+#=========================================================
+MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Sengoku 2/Data/rom"
+#=========================================================
+# MY_OUT_ROM_DIR_1 is the temporary output directory for ncommand
+MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_sengoku2"
+#=========================================================
+MY_ZIP_NAME="sengoku2"
+ROM_ID="040"
+#++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+# Do not edit the path below this line!
+#
+MY_OUT_ROM_DIR="$MY_OUT_ROM_DIR_1"/"$MY_ZIP_NAME"
+
+checkForZip
+checkForCompiledSwizzle
+cleanFilesForReRun $MY_OUT_ROM_DIR $MY_ZIP_NAME
+
+# Check if s2.bin is available, and copy it as 040-s1.s1.
+if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then
+    echo "File s2.bin not found in $MY_RAW_ROMS_DIR!"
+fi
+cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/"$ROM_ID"-s1.s1
+
+# Sound data
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v1.v1 skip=0 count=$((0x200000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v2.v2 skip=$((0x200000)) count=$((0x100000)) iflag=$IFLAG
+
+# Z80 code
+cp "$MY_RAW_ROMS_DIR"/m1.bin "$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1
+
+# 68K code
+# Note: the 040-p1.p1 CRC32 is wrong. It is the same issue that I encountered with Ninja Commando and Ghost Pilots.
+cp "$MY_RAW_ROMS_DIR"/p1.bin "$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1
+
+# Sprites
+# It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2
+./ss_unswizzle "$MY_RAW_ROMS_DIR"/c1.bin odd even
+
+( dd if=even skip=$((0x0)) count=$((0x100000)) iflag=skip_bytes,count_bytes
+    dd if=even skip=$((0x200000)) count=$((0x100000)) iflag=skip_bytes,count_bytes
+) > "$MY_OUT_ROM_DIR"/"$ROM_ID"-c2.c2
+
+( dd if=odd skip=$((0x0)) count=$((0x100000)) iflag=skip_bytes,count_bytes
+    dd if=odd skip=$((0x200000)) count=$((0x100000)) iflag=skip_bytes,count_bytes
+) > "$MY_OUT_ROM_DIR"/"$ROM_ID"-c1.c1
+
+dd if=even of="$MY_OUT_ROM_DIR"/"$ROM_ID"-c4.c4 skip=$((0x100000)) count=$((0x80000)) iflag=$IFLAG
+dd if=odd of="$MY_OUT_ROM_DIR"/"$ROM_ID"-c3.c3 skip=$((0x100000)) count=$((0x80000)) iflag=$IFLAG
+
+rm even odd
+
+zip -j -r "$MY_ZIP_NAME".zip "$MY_OUT_ROM_DIR"

--- a/GoSengoku2
+++ b/GoSengoku2
@@ -8,10 +8,10 @@
 . ./romExtractionTools.sh
 
 #=========================================================
-MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Sengoku 2/Data/rom"
+MY_RAW_ROMS_DIR="$AMAZONGAMEFOLDER"/"Sengoku 2/Data/rom"
 #=========================================================
 # MY_OUT_ROM_DIR_1 is the temporary output directory for ncommand
-MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_sengoku2"
+MY_OUT_ROM_DIR_1="$ROMOUTPUTFOLDER"
 #=========================================================
 MY_ZIP_NAME="sengoku2"
 ROM_ID="040"

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # goNCommand
 
-goNCommand is a set of Bash scripts to convert 21 games to romsets for Final Burn Alpha, MAME or FBNeo.
+goNCommand is a set of Bash scripts to convert 23 games to romsets for Final Burn Alpha, MAME or FBNeo.
 
 | ROM | ROM_NAME | GAME_NAME             |
 |-----|----------|-----------------------|
 | 005 | maglord  | Magician Lord         |
 | 007 | alpham2  | Alpha Mission II      |
+| 011 | superspy | The Super Spy         |
 | 014 | mutnat   | Mutation Nation       |
 | 017 | sengoku  | Sengoku               |
 | 020 | gpilots  | Ghost Pilots          |
@@ -16,6 +17,7 @@ goNCommand is a set of Bash scripts to convert 21 games to romsets for Final Bur
 | 039 | kotm2    | King of the Monsters 2|
 | 040 | sengoku2 | Sengoku 2             |
 | 043 | 3countb  | 3 Count Bout          |
+| 046 | tophuntr | Top Hunter            |
 | 050 | ncommand | Ninja Commando        |
 | 052 | ssideki  | Super Sidekicks       |
 | 096 | aof3     | Art of Fighting 3     |

--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
 # goNCommand
 
-goNCommand is a set of Bash scripts to convert 17 games to romsets for Final Burn Alpha, MAME or FBNeo.
+goNCommand is a set of Bash scripts to convert 19 games to romsets for Final Burn Alpha, MAME or FBNeo.
 
 | ROM | ROM_NAME | GAME_NAME             |
 |-----|----------|-----------------------|
 | 005 | maglord  | Magician Lord         |
 | 007 | alpham2  | Alpha Mission II      |
+| 014 | mutnat   | Mutation Nation       |
 | 017 | sengoku  | Sengoku               |
 | 020 | gpilots  | Ghost Pilots          |
 | 024 | lresort  | Last Resort           |
 | 032 | roboarmy | Robo Army             |
 | 037 | crsword  | Crossed Swords        |
 | 039 | kotm2    | King of the Monsters 2|
+| 040 | sengoku2 | Sengoku 2             |
 | 043 | 3countb  | 3 Count Bout          |
 | 050 | ncommand | Ninja Commando        |
 | 052 | ssideki  | Super Sidekicks       |
@@ -19,7 +21,7 @@ goNCommand is a set of Bash scripts to convert 17 games to romsets for Final Bur
 | 216 | kizuna   | Kizuna Encounter      |
 | 217 | ninjamas | Ninja Master's        |
 | 222 | samsho4  | Samurai Shodown IV    |
-| 232 | kof97    | King of Fghters '97   |
+| 232 | kof97    | King of Fighters '97  |
 | 243 | lastbld2 | Last Blade 2          |
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -1,23 +1,30 @@
 # goNCommand
 
-goNCommand is a set of Bash scripts to convert twelve games (Ninja Commando, Ghost Pilots, Art of Fighting 3, Magician Lord, Ninja Master's, Crossed Swords, Sengoku, Super Sidekicks, The Last Blade 2, Robo Army, Samurai Shodown IV, Last Resort) to romsets for Final Burn Alpha, MAME or FBNeo.
+goNCommand is a set of Bash scripts to convert 17 games to romsets for Final Burn Alpha, MAME or FBNeo.
+
+005 | maglord  | Magician Lord
+007 | alpham2  | Alpha Mission II
+017 | sengoku  | Sengoku
+020 | gpilots  | Ghost Pilots
+024 | lresort  | Last Resort
+032 | roboarmy | Robo Army
+037 | crsword  | Crossed Swords
+039 | kotm2    | King of the Monsters 2
+043 | 3countb  | 3 Count Bout
+050 | ncommand | Ninja Commando
+052 | ssideki  | Super Sidekicks
+096 | aof3     | Art of Fighting 3
+216 | kizuna   | Kizuna Encounter
+217 | ninjamas | Ninja Master's
+222 | samsho4  | Samurai Shodown IV
+232 | kof97    | King of Fghters '97
+243 | lastbld2 | Last Blade 2
 
 ## Installation
 
 Put these files in a directory of your choice:
 
-    goNCommand
-    goGPilots
-    goAoF3
-    goML
-    goNM
-    goCS
-    goSengoku
-    goSuperS
-    goLB2
-    goRA
-    goSS4_a
-    goLR
+    go*
     ss_unswizzle.c
 
 Then compile ss_unswizzle.c:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # goNCommand
 
-goNCommand is a set of Bash scripts to convert 19 games to romsets for Final Burn Alpha, MAME or FBNeo.
+goNCommand is a set of Bash scripts to convert 21 games to romsets for Final Burn Alpha, MAME or FBNeo.
 
 | ROM | ROM_NAME | GAME_NAME             |
 |-----|----------|-----------------------|
@@ -10,6 +10,7 @@ goNCommand is a set of Bash scripts to convert 19 games to romsets for Final Bur
 | 017 | sengoku  | Sengoku               |
 | 020 | gpilots  | Ghost Pilots          |
 | 024 | lresort  | Last Resort           |
+| 031 | socbrawl | Soccer Brawl          |
 | 032 | roboarmy | Robo Army             |
 | 037 | crsword  | Crossed Swords        |
 | 039 | kotm2    | King of the Monsters 2|
@@ -18,6 +19,7 @@ goNCommand is a set of Bash scripts to convert 19 games to romsets for Final Bur
 | 050 | ncommand | Ninja Commando        |
 | 052 | ssideki  | Super Sidekicks       |
 | 096 | aof3     | Art of Fighting 3     |
+| 212 | overtop  | Over Top              |
 | 216 | kizuna   | Kizuna Encounter      |
 | 217 | ninjamas | Ninja Master's        |
 | 222 | samsho4  | Samurai Shodown IV    |

--- a/README.md
+++ b/README.md
@@ -2,23 +2,25 @@
 
 goNCommand is a set of Bash scripts to convert 17 games to romsets for Final Burn Alpha, MAME or FBNeo.
 
-005 | maglord  | Magician Lord
-007 | alpham2  | Alpha Mission II
-017 | sengoku  | Sengoku
-020 | gpilots  | Ghost Pilots
-024 | lresort  | Last Resort
-032 | roboarmy | Robo Army
-037 | crsword  | Crossed Swords
-039 | kotm2    | King of the Monsters 2
-043 | 3countb  | 3 Count Bout
-050 | ncommand | Ninja Commando
-052 | ssideki  | Super Sidekicks
-096 | aof3     | Art of Fighting 3
-216 | kizuna   | Kizuna Encounter
-217 | ninjamas | Ninja Master's
-222 | samsho4  | Samurai Shodown IV
-232 | kof97    | King of Fghters '97
-243 | lastbld2 | Last Blade 2
+| ROM | ROM_NAME | GAME_NAME             |
+|-----|----------|-----------------------|
+| 005 | maglord  | Magician Lord         |
+| 007 | alpham2  | Alpha Mission II      |
+| 017 | sengoku  | Sengoku               |
+| 020 | gpilots  | Ghost Pilots          |
+| 024 | lresort  | Last Resort           |
+| 032 | roboarmy | Robo Army             |
+| 037 | crsword  | Crossed Swords        |
+| 039 | kotm2    | King of the Monsters 2|
+| 043 | 3countb  | 3 Count Bout          |
+| 050 | ncommand | Ninja Commando        |
+| 052 | ssideki  | Super Sidekicks       |
+| 096 | aof3     | Art of Fighting 3     |
+| 216 | kizuna   | Kizuna Encounter      |
+| 217 | ninjamas | Ninja Master's        |
+| 222 | samsho4  | Samurai Shodown IV    |
+| 232 | kof97    | King of Fghters '97   |
+| 243 | lastbld2 | Last Blade 2          |
 
 ## Installation
 

--- a/goAoF3
+++ b/goAoF3
@@ -6,10 +6,10 @@
 . ./romExtractionTools.sh
 
 #=========================================================
-MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Art of Fighting 3 - The Path of The/Data/rom"
+MY_RAW_ROMS_DIR="$AMAZONGAMEFOLDER"/"Art of Fighting 3 - The Path of The/Data/rom"
 #=========================================================
 # MY_OUT_ROM_DIR_1 is the temporary output directory for ncommand
-MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_aof3"
+MY_OUT_ROM_DIR_1="$ROMOUTPUTFOLDER"
 #=========================================================
 MY_ZIP_NAME=aof3
 ROM_ID="096"

--- a/goAoF3
+++ b/goAoF3
@@ -12,6 +12,7 @@ MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Art of Fighting 3 - The Path of The/
 MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_aof3"
 #=========================================================
 MY_ZIP_NAME=aof3
+ROM_ID="096"
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 # Do not edit the path below this line!
 #
@@ -26,23 +27,23 @@ if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then
     echo "File s2.bin not found in $MY_RAW_ROMS_DIR!"
 fi
 
-cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/096-s1.s1
+cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/"$ROM_ID"-s1.s1
 
 
 # Sound data
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/096-v1.v1 skip=0 count=$((0x200000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v1.v1 skip=0 count=$((0x200000)) iflag=$IFLAG
 
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/096-v2.v2 skip=$((0x200000)) count=$((0x200000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v2.v2 skip=$((0x200000)) count=$((0x200000)) iflag=$IFLAG
 
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/096-v3.v3 skip=$(( $((0x200000))+$((0x200000)) )) count=$((0x200000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v3.v3 skip=$(( $((0x200000))+$((0x200000)) )) count=$((0x200000)) iflag=$IFLAG
 
 # Z80 code
-dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/096-m1.m1 skip=$((0x0)) count=$((0x020000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1 skip=$((0x0)) count=$((0x020000)) iflag=$IFLAG
 
 # 68K code
 # Note: the 096-p1.p1 CRC32 is wrong. It is the same issue that I encountered with Ninja Commando and Ghost Pilots.
-dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/096-p1.p1 skip=$((0x0)) count=$((0x100000)) iflag=$IFLAG
-dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/096-p2.sp2 skip=$((0x100000)) count=$((0x200000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 skip=$((0x0)) count=$((0x100000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p2.sp2 skip=$((0x100000)) count=$((0x200000)) iflag=$IFLAG
 
 # Sprites
 # It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2
@@ -50,22 +51,22 @@ dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/096-p2.sp2 skip=$((0x100000
 split -b 4194304 even even_d
 split -b 4194304 odd odd_d
 
-mv even_daa "$MY_OUT_ROM_DIR"/096-c2.c2
-mv even_dab "$MY_OUT_ROM_DIR"/096-c4.c4
-mv even_dac "$MY_OUT_ROM_DIR"/096-c6.c6
-mv even_dad "$MY_OUT_ROM_DIR"/096-c8.c8
+mv even_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c2.c2
+mv even_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c4.c4
+mv even_dac "$MY_OUT_ROM_DIR"/"$ROM_ID"-c6.c6
+mv even_dad "$MY_OUT_ROM_DIR"/"$ROM_ID"-c8.c8
 
-mv odd_daa "$MY_OUT_ROM_DIR"/096-c1.c1
-mv odd_dab "$MY_OUT_ROM_DIR"/096-c3.c3
-mv odd_dac "$MY_OUT_ROM_DIR"/096-c5.c5
-mv odd_dad "$MY_OUT_ROM_DIR"/096-c7.c7
+mv odd_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c1.c1
+mv odd_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c3.c3
+mv odd_dac "$MY_OUT_ROM_DIR"/"$ROM_ID"-c5.c5
+mv odd_dad "$MY_OUT_ROM_DIR"/"$ROM_ID"-c7.c7
 
 rm even odd
 
 zip -j -r aof3.zip_original "$MY_OUT_ROM_DIR"
 
 # Modification of the 68K file to comply with FBNeo CRC32: replace byte at address 0x115 (value = 02) by (value = 00).
-printf '\x00' | dd of="$MY_OUT_ROM_DIR"/096-p1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
+printf '\x00' | dd of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
 
 zip -j -r "$MY_ZIP_NAME".zip "$MY_OUT_ROM_DIR"
 

--- a/goAoF3
+++ b/goAoF3
@@ -26,16 +26,12 @@ cleanFilesForReRun $MY_OUT_ROM_DIR $MY_ZIP_NAME
 if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then
     echo "File s2.bin not found in $MY_RAW_ROMS_DIR!"
 fi
-
 cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/"$ROM_ID"-s1.s1
-
 
 # Sound data
 dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v1.v1 skip=0 count=$((0x200000)) iflag=$IFLAG
-
 dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v2.v2 skip=$((0x200000)) count=$((0x200000)) iflag=$IFLAG
-
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v3.v3 skip=$(( $((0x200000))+$((0x200000)) )) count=$((0x200000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v3.v3 skip=$((0x400000)) count=$((0x200000)) iflag=$IFLAG
 
 # Z80 code
 dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1 skip=$((0x0)) count=$((0x020000)) iflag=$IFLAG
@@ -44,6 +40,8 @@ dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1 skip=$((0x0
 # Note: the 096-p1.p1 CRC32 is wrong. It is the same issue that I encountered with Ninja Commando and Ghost Pilots.
 dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 skip=$((0x0)) count=$((0x100000)) iflag=$IFLAG
 dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p2.sp2 skip=$((0x100000)) count=$((0x200000)) iflag=$IFLAG
+# Modification of the 68K file to comply with FBNeo CRC32: replace byte at address 0x115 (value = 02) by (value = 00).
+printf '\x00' | dd of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
 
 # Sprites
 # It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2
@@ -63,10 +61,4 @@ mv odd_dad "$MY_OUT_ROM_DIR"/"$ROM_ID"-c7.c7
 
 rm even odd
 
-zip -j -r aof3.zip_original "$MY_OUT_ROM_DIR"
-
-# Modification of the 68K file to comply with FBNeo CRC32: replace byte at address 0x115 (value = 02) by (value = 00).
-printf '\x00' | dd of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
-
 zip -j -r "$MY_ZIP_NAME".zip "$MY_OUT_ROM_DIR"
-

--- a/goAoF3
+++ b/goAoF3
@@ -20,7 +20,7 @@ MY_OUT_ROM_DIR="$MY_OUT_ROM_DIR_1"/"$MY_ZIP_NAME"
 
 checkForZip
 checkForCompiledSwizzle
-cleanFilesForReRun $MY_OUT_ROM_DIR, $MY_ZIP_NAME
+cleanFilesForReRun $MY_OUT_ROM_DIR $MY_ZIP_NAME
 
 # Check if s2.bin is available, and copy it as 096-s1.s1.
 if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then

--- a/goAoF3
+++ b/goAoF3
@@ -3,6 +3,8 @@
 # Lionel Cordesses, 2023.
 # Script to build a MAME or FBAlpha romset (extension: .zip_original), and also FBNeo romset (extension: .zip) for Art of Fighting 3 from the Amazon Prime Gaming game.
 
+. ./romExtractionTools.sh
+
 #=========================================================
 MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Art of Fighting 3 - The Path of The/Data/rom"
 #=========================================================
@@ -15,25 +17,9 @@ MY_ZIP_NAME=aof3
 #
 MY_OUT_ROM_DIR="$MY_OUT_ROM_DIR_1"/"$MY_ZIP_NAME"
 
-# Test if zip is installed.
-if ! command -v zip &> /dev/null
-then
-    echo "zip could not be found. Maybe "sudo apt-get install zip"?"
-    exit
-fi
-
-# Test is ss_unswizzle.c has been compiled.
-if ! command -v ./ss_unswizzle &> /dev/null
-then
-    echo "ss_unswizzle could not be found. You may try: gcc -o ss_unswizzle ss_unswizzle.c"
-    exit
-fi
-
-# Delete files and directories froms previous runs.
-rm -r "$MY_OUT_ROM_DIR"
-rm "$MY_ZIP_NAME".zip
-rm "$MY_ZIP_NAME".zip_original
-mkdir -p "$MY_OUT_ROM_DIR"
+checkForZip
+checkForCompiledSwizzle
+cleanFilesForReRun $MY_OUT_ROM_DIR, $MY_ZIP_NAME
 
 # Check if s2.bin is available, and copy it as 096-s1.s1.
 if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then
@@ -44,19 +30,19 @@ cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/096-s1.s1
 
 
 # Sound data
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/096-v1.v1 skip=0 count=$((0x200000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/096-v1.v1 skip=0 count=$((0x200000)) iflag=$IFLAG
 
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/096-v2.v2 skip=$((0x200000)) count=$((0x200000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/096-v2.v2 skip=$((0x200000)) count=$((0x200000)) iflag=$IFLAG
 
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/096-v3.v3 skip=$(( $((0x200000))+$((0x200000)) )) count=$((0x200000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/096-v3.v3 skip=$(( $((0x200000))+$((0x200000)) )) count=$((0x200000)) iflag=$IFLAG
 
 # Z80 code
-dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/096-m1.m1 skip=$((0x0)) count=$((0x020000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/096-m1.m1 skip=$((0x0)) count=$((0x020000)) iflag=$IFLAG
 
 # 68K code
 # Note: the 096-p1.p1 CRC32 is wrong. It is the same issue that I encountered with Ninja Commando and Ghost Pilots.
-dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/096-p1.p1 skip=$((0x0)) count=$((0x100000)) iflag=skip_bytes,count_bytes
-dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/096-p2.sp2 skip=$((0x100000)) count=$((0x200000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/096-p1.p1 skip=$((0x0)) count=$((0x100000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/096-p2.sp2 skip=$((0x100000)) count=$((0x200000)) iflag=$IFLAG
 
 # Sprites
 # It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2

--- a/goCS
+++ b/goCS
@@ -6,10 +6,10 @@
 . ./romExtractionTools.sh
 
 #=========================================================
-MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Crossed Swords/Data/rom"
+MY_RAW_ROMS_DIR="$AMAZONGAMEFOLDER"/"Crossed Swords/Data/rom"
 #=========================================================
 # MY_OUT_ROM_DIR_1 is the temporary output directory for ninjamas
-MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_cs"
+MY_OUT_ROM_DIR_1="$ROMOUTPUTFOLDER"
 #=========================================================
 MY_ZIP_NAME=crsword
 ROM_ID="037"

--- a/goCS
+++ b/goCS
@@ -12,6 +12,7 @@ MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Crossed Swords/Data/rom"
 MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_cs"
 #=========================================================
 MY_ZIP_NAME=crsword
+ROM_ID="037"
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 # Do not edit the path below this line!
 #
@@ -26,28 +27,28 @@ if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then
     echo "File s2.bin not found in $MY_RAW_ROMS_DIR!"
 fi
 
-cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/037-s1.s1
+cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/"$ROM_ID"-s1.s1
 
 
 # Sound data
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/037-v1.v1 skip=0 count=$((0x100000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v1.v1 skip=0 count=$((0x100000)) iflag=$IFLAG
 
-#dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/037-v2.v2 skip=$((0x400000)) count=$((0x400000)) iflag=$IFLAG
+#dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v2.v2 skip=$((0x400000)) count=$((0x400000)) iflag=$IFLAG
 
 
 # Z80 code
-dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/037-m1.m1b skip=$((0x0)) count=$((0x010000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1b skip=$((0x0)) count=$((0x010000)) iflag=$IFLAG
 # Create the 64KB of 0xff
 dd if=/dev/zero ibs=1k count=64 | tr "\000" "\377" >tmp0xFF.bin
 # Concat 050-m1.m1 and tmp0xFF.bin to create the final 050-m1.m1.
-cat "$MY_OUT_ROM_DIR"/037-m1.m1b tmp0xFF.bin >"$MY_OUT_ROM_DIR"/037-m1.m1
-rm "$MY_OUT_ROM_DIR"/037-m1.m1b
+cat "$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1b tmp0xFF.bin >"$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1
+rm "$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1b
 rm tmp0xFF.bin
 
 # 68K code
 # Note: the 037-p1.p1 CRC32 is wrong. It is the same issue that I encountered with Ninja Commando and Ghost Pilots.
-dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/037-p1.p1 skip=$((0x0)) count=$((0x080000)) iflag=$IFLAG
-#dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/037-p2.sp2 skip=$((0x100000)) count=$((0x200000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 skip=$((0x0)) count=$((0x080000)) iflag=$IFLAG
+#dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p2.sp2 skip=$((0x100000)) count=$((0x200000)) iflag=$IFLAG
 
 # Sprites
 # It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2
@@ -55,18 +56,18 @@ dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/037-p1.p1 skip=$((0x0)) cou
 split -b 1048576 even even_d
 split -b 1048576 odd odd_d
 
-mv even_daa "$MY_OUT_ROM_DIR"/037-c2.c2
-mv even_dab "$MY_OUT_ROM_DIR"/037-c4.c4
+mv even_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c2.c2
+mv even_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c4.c4
 
-mv odd_daa "$MY_OUT_ROM_DIR"/037-c1.c1
-mv odd_dab "$MY_OUT_ROM_DIR"/037-c3.c3
+mv odd_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c1.c1
+mv odd_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c3.c3
 
 rm even odd
 
 zip -j -r "$MY_ZIP_NAME".zip_original "$MY_OUT_ROM_DIR"
 
 # Modification of the first 68K file to comply with FBNeo CRC32: replace byte at address 0x115 (value = 02) by (value = 00).
-printf '\x00' | dd of="$MY_OUT_ROM_DIR"/037-p1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
+printf '\x00' | dd of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
 
 zip -j -r "$MY_ZIP_NAME".zip "$MY_OUT_ROM_DIR"
 

--- a/goCS
+++ b/goCS
@@ -26,15 +26,10 @@ cleanFilesForReRun $MY_OUT_ROM_DIR $MY_ZIP_NAME
 if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then
     echo "File s2.bin not found in $MY_RAW_ROMS_DIR!"
 fi
-
 cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/"$ROM_ID"-s1.s1
-
 
 # Sound data
 dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v1.v1 skip=0 count=$((0x100000)) iflag=$IFLAG
-
-#dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v2.v2 skip=$((0x400000)) count=$((0x400000)) iflag=$IFLAG
-
 
 # Z80 code
 dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1b skip=$((0x0)) count=$((0x010000)) iflag=$IFLAG
@@ -48,7 +43,8 @@ rm tmp0xFF.bin
 # 68K code
 # Note: the 037-p1.p1 CRC32 is wrong. It is the same issue that I encountered with Ninja Commando and Ghost Pilots.
 dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 skip=$((0x0)) count=$((0x080000)) iflag=$IFLAG
-#dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p2.sp2 skip=$((0x100000)) count=$((0x200000)) iflag=$IFLAG
+# Modification of the first 68K file to comply with FBNeo CRC32: replace byte at address 0x115 (value = 02) by (value = 00).
+printf '\x00' | dd of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
 
 # Sprites
 # It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2
@@ -64,11 +60,4 @@ mv odd_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c3.c3
 
 rm even odd
 
-zip -j -r "$MY_ZIP_NAME".zip_original "$MY_OUT_ROM_DIR"
-
-# Modification of the first 68K file to comply with FBNeo CRC32: replace byte at address 0x115 (value = 02) by (value = 00).
-printf '\x00' | dd of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
-
 zip -j -r "$MY_ZIP_NAME".zip "$MY_OUT_ROM_DIR"
-
-

--- a/goCS
+++ b/goCS
@@ -20,7 +20,7 @@ MY_OUT_ROM_DIR="$MY_OUT_ROM_DIR_1"/"$MY_ZIP_NAME"
 
 checkForZip
 checkForCompiledSwizzle
-cleanFilesForReRun $MY_OUT_ROM_DIR, $MY_ZIP_NAME
+cleanFilesForReRun $MY_OUT_ROM_DIR $MY_ZIP_NAME
 
 # Check if s2.bin is available, and copy it as 037-s1.s1.
 if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then

--- a/goCS
+++ b/goCS
@@ -3,6 +3,8 @@
 # Lionel Cordesses, 2023.
 # Script to build a MAME or FBAlpha romset (extension: .zip_original), and also FBNeo romset (extension: .zip) for Crossed Swords, from the Amazon Prime Gaming game.
 
+. ./romExtractionTools.sh
+
 #=========================================================
 MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Crossed Swords/Data/rom"
 #=========================================================
@@ -15,25 +17,9 @@ MY_ZIP_NAME=crsword
 #
 MY_OUT_ROM_DIR="$MY_OUT_ROM_DIR_1"/"$MY_ZIP_NAME"
 
-# Test if zip is installed.
-if ! command -v zip &> /dev/null
-then
-    echo "zip could not be found. Maybe "sudo apt-get install zip"?"
-    exit
-fi
-
-# Test is ss_unswizzle.c has been compiled.
-if ! command -v ./ss_unswizzle &> /dev/null
-then
-    echo "ss_unswizzle could not be found. You may try: gcc -o ss_unswizzle ss_unswizzle.c"
-    exit
-fi
-
-# Delete files and directories froms previous runs.
-rm -r "$MY_OUT_ROM_DIR"
-rm "$MY_ZIP_NAME".zip
-rm "$MY_ZIP_NAME".zip_original
-mkdir -p "$MY_OUT_ROM_DIR"
+checkForZip
+checkForCompiledSwizzle
+cleanFilesForReRun $MY_OUT_ROM_DIR, $MY_ZIP_NAME
 
 # Check if s2.bin is available, and copy it as 037-s1.s1.
 if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then
@@ -44,13 +30,13 @@ cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/037-s1.s1
 
 
 # Sound data
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/037-v1.v1 skip=0 count=$((0x100000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/037-v1.v1 skip=0 count=$((0x100000)) iflag=$IFLAG
 
-#dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/037-v2.v2 skip=$((0x400000)) count=$((0x400000)) iflag=skip_bytes,count_bytes
+#dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/037-v2.v2 skip=$((0x400000)) count=$((0x400000)) iflag=$IFLAG
 
 
 # Z80 code
-dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/037-m1.m1b skip=$((0x0)) count=$((0x010000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/037-m1.m1b skip=$((0x0)) count=$((0x010000)) iflag=$IFLAG
 # Create the 64KB of 0xff
 dd if=/dev/zero ibs=1k count=64 | tr "\000" "\377" >tmp0xFF.bin
 # Concat 050-m1.m1 and tmp0xFF.bin to create the final 050-m1.m1.
@@ -60,8 +46,8 @@ rm tmp0xFF.bin
 
 # 68K code
 # Note: the 037-p1.p1 CRC32 is wrong. It is the same issue that I encountered with Ninja Commando and Ghost Pilots.
-dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/037-p1.p1 skip=$((0x0)) count=$((0x080000)) iflag=skip_bytes,count_bytes
-#dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/037-p2.sp2 skip=$((0x100000)) count=$((0x200000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/037-p1.p1 skip=$((0x0)) count=$((0x080000)) iflag=$IFLAG
+#dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/037-p2.sp2 skip=$((0x100000)) count=$((0x200000)) iflag=$IFLAG
 
 # Sprites
 # It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2

--- a/goGPilots
+++ b/goGPilots
@@ -32,18 +32,19 @@ cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/"$ROM_ID"-s1.s1
 
 # Sound data
 dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v11.v11 skip=0 count=$((0x100000)) iflag=$IFLAG
-
 dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v12.v12 skip=$((0x100000)) count=$((0x080000)) iflag=$IFLAG
-
 dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v21.v21 skip=$(( $((0x100000))+$((0x080000)) )) count=$((0x080000)) iflag=$IFLAG
 
 # Z80 code
 dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1 skip=$((0x0)) count=$((0x020000)) iflag=$IFLAG
 
 # 68K code
-# Note: the 020-p1.p1 CRC32 is wrong. It is the same issue that I encountered with Ninja Commando.
+# Note: the p1 CRC32 is wrong. It is the same issue that I encountered with Ninja Commando.
 dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 skip=$((0x0)) count=$((0x080000)) iflag=$IFLAG
 dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p2.p2 skip=$((0x080000)) count=$((0x020000)) iflag=$IFLAG
+# Modification of the first 68K file to comply with FBNeo CRC32: replace byte at address 0x115 (value = 02) by (value = 00).
+printf '\x00' | dd of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
+
 
 # Sprites
 # It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2
@@ -59,12 +60,4 @@ mv odd_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c3.c3
 
 rm even odd
 
-zip -j -r "$MY_ZIP_NAME".zip_original "$MY_OUT_ROM_DIR"
-
-# Modification of the first 68K file to comply with FBNeo CRC32: replace byte at address 0x115 (value = 02) by (value = 00).
-printf '\x00' | dd of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
-
 zip -j -r "$MY_ZIP_NAME".zip "$MY_OUT_ROM_DIR"
-
-
-

--- a/goGPilots
+++ b/goGPilots
@@ -20,7 +20,7 @@ MY_OUT_ROM_DIR="$MY_OUT_ROM_DIR_1"/"$MY_ZIP_NAME"
 
 checkForZip
 checkForCompiledSwizzle
-cleanFilesForReRun $MY_OUT_ROM_DIR, $MY_ZIP_NAME
+cleanFilesForReRun $MY_OUT_ROM_DIR $MY_ZIP_NAME
 
 # Check if s2.bin is available, and copy it as 020-s1.s1.
 if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then

--- a/goGPilots
+++ b/goGPilots
@@ -6,10 +6,10 @@
 . ./romExtractionTools.sh
 
 #=========================================================
-MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Ghost Pilots/Data/rom"
+MY_RAW_ROMS_DIR="$AMAZONGAMEFOLDER"/"Ghost Pilots/Data/rom"
 #=========================================================
 # MY_OUT_ROM_DIR_1 is the temporary output directory for ncommand
-MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_gpilots"
+MY_OUT_ROM_DIR_1="$ROMOUTPUTFOLDER"
 #=========================================================
 MY_ZIP_NAME=gpilots
 ROM_ID="020"

--- a/goGPilots
+++ b/goGPilots
@@ -3,6 +3,8 @@
 # Lionel Cordesses, 2023.
 # Script to build a MAME or FBAlpha romset (extension: .zip_original), and also FBNeo romset (extension: .zip) for Ghost Pilots from the Amazon Prime Gaming game.
 
+. ./romExtractionTools.sh
+
 #=========================================================
 MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Ghost Pilots/Data/rom"
 #=========================================================
@@ -15,25 +17,9 @@ MY_ZIP_NAME=gpilots
 #
 MY_OUT_ROM_DIR="$MY_OUT_ROM_DIR_1"/"$MY_ZIP_NAME"
 
-# Test if zip is installed.
-if ! command -v zip &> /dev/null
-then
-    echo "zip could not be found. Maybe "sudo apt-get install zip"?"
-    exit
-fi
-
-# Test is ss_unswizzle.c has been compiled.
-if ! command -v ./ss_unswizzle &> /dev/null
-then
-    echo "ss_unswizzle could not be found. You may try: gcc -o ss_unswizzle ss_unswizzle.c"
-    exit
-fi
-
-# Delete files and directories froms previous runs.
-rm -r "$MY_OUT_ROM_DIR"
-rm "$MY_ZIP_NAME".zip
-rm "$MY_ZIP_NAME".zip_original
-mkdir -p "$MY_OUT_ROM_DIR"
+checkForZip
+checkForCompiledSwizzle
+cleanFilesForReRun $MY_OUT_ROM_DIR, $MY_ZIP_NAME
 
 # Check if s2.bin is available, and copy it as 020-s1.s1.
 if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then
@@ -44,19 +30,19 @@ cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/020-s1.s1
 
 
 # Sound data
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/020-v11.v11 skip=0 count=$((0x100000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/020-v11.v11 skip=0 count=$((0x100000)) iflag=$IFLAG
 
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/020-v12.v12 skip=$((0x100000)) count=$((0x080000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/020-v12.v12 skip=$((0x100000)) count=$((0x080000)) iflag=$IFLAG
 
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/020-v21.v21 skip=$(( $((0x100000))+$((0x080000)) )) count=$((0x080000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/020-v21.v21 skip=$(( $((0x100000))+$((0x080000)) )) count=$((0x080000)) iflag=$IFLAG
 
 # Z80 code
-dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/020-m1.m1 skip=$((0x0)) count=$((0x020000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/020-m1.m1 skip=$((0x0)) count=$((0x020000)) iflag=$IFLAG
 
 # 68K code
 # Note: the 020-p1.p1 CRC32 is wrong. It is the same issue that I encountered with Ninja Commando.
-dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/020-p1.p1 skip=$((0x0)) count=$((0x080000)) iflag=skip_bytes,count_bytes
-dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/020-p2.p2 skip=$((0x080000)) count=$((0x020000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/020-p1.p1 skip=$((0x0)) count=$((0x080000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/020-p2.p2 skip=$((0x080000)) count=$((0x020000)) iflag=$IFLAG
 
 # Sprites
 # It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2

--- a/goGPilots
+++ b/goGPilots
@@ -12,6 +12,7 @@ MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Ghost Pilots/Data/rom"
 MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_gpilots"
 #=========================================================
 MY_ZIP_NAME=gpilots
+ROM_ID="020"
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 # Do not edit the path below this line!
 #
@@ -26,23 +27,23 @@ if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then
     echo "File s2.bin not found in $MY_RAW_ROMS_DIR!"
 fi
 
-cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/020-s1.s1
+cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/"$ROM_ID"-s1.s1
 
 
 # Sound data
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/020-v11.v11 skip=0 count=$((0x100000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v11.v11 skip=0 count=$((0x100000)) iflag=$IFLAG
 
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/020-v12.v12 skip=$((0x100000)) count=$((0x080000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v12.v12 skip=$((0x100000)) count=$((0x080000)) iflag=$IFLAG
 
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/020-v21.v21 skip=$(( $((0x100000))+$((0x080000)) )) count=$((0x080000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v21.v21 skip=$(( $((0x100000))+$((0x080000)) )) count=$((0x080000)) iflag=$IFLAG
 
 # Z80 code
-dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/020-m1.m1 skip=$((0x0)) count=$((0x020000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1 skip=$((0x0)) count=$((0x020000)) iflag=$IFLAG
 
 # 68K code
 # Note: the 020-p1.p1 CRC32 is wrong. It is the same issue that I encountered with Ninja Commando.
-dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/020-p1.p1 skip=$((0x0)) count=$((0x080000)) iflag=$IFLAG
-dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/020-p2.p2 skip=$((0x080000)) count=$((0x020000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 skip=$((0x0)) count=$((0x080000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p2.p2 skip=$((0x080000)) count=$((0x020000)) iflag=$IFLAG
 
 # Sprites
 # It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2
@@ -50,18 +51,18 @@ dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/020-p2.p2 skip=$((0x080000)
 split -b 1048576 even even_d
 split -b 1048576 odd odd_d
 
-mv even_daa "$MY_OUT_ROM_DIR"/020-c2.c2
-mv even_dab "$MY_OUT_ROM_DIR"/020-c4.c4
+mv even_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c2.c2
+mv even_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c4.c4
 
-mv odd_daa "$MY_OUT_ROM_DIR"/020-c1.c1
-mv odd_dab "$MY_OUT_ROM_DIR"/020-c3.c3
+mv odd_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c1.c1
+mv odd_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c3.c3
 
 rm even odd
 
 zip -j -r "$MY_ZIP_NAME".zip_original "$MY_OUT_ROM_DIR"
 
 # Modification of the first 68K file to comply with FBNeo CRC32: replace byte at address 0x115 (value = 02) by (value = 00).
-printf '\x00' | dd of="$MY_OUT_ROM_DIR"/020-p1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
+printf '\x00' | dd of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
 
 zip -j -r "$MY_ZIP_NAME".zip "$MY_OUT_ROM_DIR"
 

--- a/goKizuna
+++ b/goKizuna
@@ -1,0 +1,71 @@
+#!/bin/bash
+#
+# Tomasz Bednarz, 2023
+# based on work by
+# Lionel Cordesses, 2023.
+# Script to build a MAME or FBAlpha romset (extension: .zip_original), and also FBNeo romset (extension: .zip) for Kizuna Encounter from the Amazon Prime Gaming game.
+
+. ./romExtractionTools.sh
+
+#=========================================================
+MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Kizuna Encounter - Super Tag Battle/Data/rom"
+#=========================================================
+# MY_OUT_ROM_DIR_1 is the temporary output directory for ncommand
+MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_kizuna"
+#=========================================================
+MY_ZIP_NAME="kizuna"
+ROM_ID="216"
+#++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+# Do not edit the path below this line!
+#
+MY_OUT_ROM_DIR="$MY_OUT_ROM_DIR_1"/"$MY_ZIP_NAME"
+
+checkForZip
+checkForCompiledSwizzle
+cleanFilesForReRun $MY_OUT_ROM_DIR $MY_ZIP_NAME
+
+# Check if s2.bin is available, and copy it as 216-s1.s1.
+if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then
+    echo "File s2.bin not found in $MY_RAW_ROMS_DIR!"
+fi
+
+cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/"$ROM_ID"-s1.s1
+
+# Sound data
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/059-v1.v1 skip=0 count=$((0x200000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v2.v2 skip=$((0x200000)) count=$((0x200000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/059-v3.v3 skip=$((0x400000)) count=$((0x200000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v4.v4 skip=$((0x600000)) count=$((0x200000)) iflag=$IFLAG
+
+# Z80 code
+cp "$MY_RAW_ROMS_DIR"/m1.bin "$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1
+
+# 68K code
+# Note: the 096-p1.p1 CRC32 is wrong. It is the same issue that I encountered with Ninja Commando and Ghost Pilots.
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of=p1.prov skip=0 count=$((0x100000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of=p2.prov skip=$((0x100000)) count=$((0x100000)) iflag=$IFLAG
+
+cat p2.prov p1.prov >"$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1
+
+rm p2.prov p1.prov
+
+# Sprites
+# It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2
+./ss_unswizzle "$MY_RAW_ROMS_DIR"/c1.bin odd even
+split -b 2097152 even even_d
+split -b 2097152 odd odd_d
+
+mv even_daa "$MY_OUT_ROM_DIR"/059-c2.c2
+mv even_dae "$MY_OUT_ROM_DIR"/059-c6.c6
+mv even_dag "$MY_OUT_ROM_DIR"/059-c8.c8
+
+mv odd_daa "$MY_OUT_ROM_DIR"/059-c1.c1
+mv odd_dae "$MY_OUT_ROM_DIR"/059-c5.c5
+mv odd_dag "$MY_OUT_ROM_DIR"/059-c7.c7
+
+cat odd_dac odd_dad >"$MY_OUT_ROM_DIR"/"$ROM_ID"-c3.c3
+cat even_dac even_dad >"$MY_OUT_ROM_DIR"/"$ROM_ID"-c4.c4
+
+rm even odd odd_dab odd_dac odd_dad odd_daf even_dab even_dac even_dad even_daf
+
+zip -j -r "$MY_ZIP_NAME".zip "$MY_OUT_ROM_DIR"

--- a/goKizuna
+++ b/goKizuna
@@ -28,7 +28,6 @@ cleanFilesForReRun $MY_OUT_ROM_DIR $MY_ZIP_NAME
 if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then
     echo "File s2.bin not found in $MY_RAW_ROMS_DIR!"
 fi
-
 cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/"$ROM_ID"-s1.s1
 
 # Sound data
@@ -41,13 +40,10 @@ dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v4.v4 skip=$((0x6
 cp "$MY_RAW_ROMS_DIR"/m1.bin "$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1
 
 # 68K code
-# Note: the 096-p1.p1 CRC32 is wrong. It is the same issue that I encountered with Ninja Commando and Ghost Pilots.
-dd if="$MY_RAW_ROMS_DIR"/p1.bin of=p1.prov skip=0 count=$((0x100000)) iflag=$IFLAG
-dd if="$MY_RAW_ROMS_DIR"/p1.bin of=p2.prov skip=$((0x100000)) count=$((0x100000)) iflag=$IFLAG
-
-cat p2.prov p1.prov >"$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1
-
-rm p2.prov p1.prov
+(
+    dd if="$MY_RAW_ROMS_DIR"/p1.bin skip=$((0x100000)) count=$((0x100000)) iflag=$IFLAG
+    dd if="$MY_RAW_ROMS_DIR"/p1.bin skip=0 count=$((0x100000)) iflag=$IFLAG
+) > "$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1
 
 # Sprites
 # It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2

--- a/goKizuna
+++ b/goKizuna
@@ -8,10 +8,10 @@
 . ./romExtractionTools.sh
 
 #=========================================================
-MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Kizuna Encounter - Super Tag Battle/Data/rom"
+MY_RAW_ROMS_DIR="$AMAZONGAMEFOLDER"/"Kizuna Encounter - Super Tag Battle/Data/rom"
 #=========================================================
 # MY_OUT_ROM_DIR_1 is the temporary output directory for ncommand
-MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_kizuna"
+MY_OUT_ROM_DIR_1="$ROMOUTPUTFOLDER"
 #=========================================================
 MY_ZIP_NAME="kizuna"
 ROM_ID="216"

--- a/goKotM2
+++ b/goKotM2
@@ -1,0 +1,58 @@
+#!/bin/bash
+#
+# Tomasz Bednarz, 2023
+# based on work by
+# Lionel Cordesses, 2023.
+# Script to build a MAME or FBAlpha romset (extension: .zip_original), and also FBNeo romset (extension: .zip) for Last Blade 2, from the Amazon Prime Gaming game.
+
+. ./romExtractionTools.sh
+
+#=========================================================
+MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/King of the Monsters 2/Data/rom"
+#=========================================================
+# MY_OUT_ROM_DIR_1 is the temporary output directory for ncommand
+MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_kotm2"
+#=========================================================
+MY_ZIP_NAME=kotm2
+ROM_ID="039"
+#++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+# Do not edit the path below this line!
+#
+MY_OUT_ROM_DIR="$MY_OUT_ROM_DIR_1"/"$MY_ZIP_NAME"
+
+checkForZip
+checkForCompiledSwizzle
+cleanFilesForReRun $MY_OUT_ROM_DIR $MY_ZIP_NAME
+
+# Check if s2.bin is available, and copy it as rom_id-s1.bin.
+if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then
+    echo "File s2.bin not found in $MY_RAW_ROMS_DIR!"
+fi
+cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/"$ROM_ID"-s1.bin
+
+# Sound data
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v2.bin skip=0 count=$((0x200000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v4.bin skip=$((0x200000)) count=$((0x100000)) iflag=$IFLAG
+
+# Z80 code
+cp "$MY_RAW_ROMS_DIR"/m1.bin "$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.bin
+
+# 68K code
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.bin skip=$((0x0)) count=$((0x80000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p2.bin skip=$((0x80000)) count=$((0x80000)) iflag=$IFLAG
+
+# Sprites
+# It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2
+./ss_unswizzle "$MY_RAW_ROMS_DIR"/c1.bin odd even
+split -b 524288 even even_d
+split -b 524288 odd odd_d
+
+cat  odd_daa odd_dab odd_dae odd_daf >"$MY_OUT_ROM_DIR"/"$ROM_ID"-c1.c1
+cat  even_daa even_dab even_dae even_daf >"$MY_OUT_ROM_DIR"/"$ROM_ID"-c2.c2
+
+mv odd_dac "$MY_OUT_ROM_DIR"/"$ROM_ID"-c3.c3
+mv even_dac "$MY_OUT_ROM_DIR"/"$ROM_ID"-c4.c4
+
+rm even odd even_daa even_dab even_dad even_dae even_daf odd_daa odd_dab odd_dad odd_dae odd_daf
+
+zip -j -r "$MY_ZIP_NAME".zip "$MY_OUT_ROM_DIR"

--- a/goKotM2
+++ b/goKotM2
@@ -8,10 +8,10 @@
 . ./romExtractionTools.sh
 
 #=========================================================
-MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/King of the Monsters 2/Data/rom"
+MY_RAW_ROMS_DIR="$AMAZONGAMEFOLDER"/"King of the Monsters 2/Data/rom"
 #=========================================================
 # MY_OUT_ROM_DIR_1 is the temporary output directory for ncommand
-MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_kotm2"
+MY_OUT_ROM_DIR_1="$ROMOUTPUTFOLDER"
 #=========================================================
 MY_ZIP_NAME=kotm2
 ROM_ID="039"

--- a/goLB2
+++ b/goLB2
@@ -1,9 +1,11 @@
 #!/bin/bash
 #
-# Tomasz Bednarz, 2023 
-# based on work by 
+# Tomasz Bednarz, 2023
+# based on work by
 # Lionel Cordesses, 2023.
 # Script to build a MAME or FBAlpha romset (extension: .zip_original), and also FBNeo romset (extension: .zip) for Last Blade 2, from the Amazon Prime Gaming game.
+
+. ./romExtractionTools.sh
 
 #=========================================================
 MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/The Last Blade 2/Data/rom"
@@ -17,25 +19,9 @@ MY_ZIP_NAME=lastbld2
 #
 MY_OUT_ROM_DIR="$MY_OUT_ROM_DIR_1"/"$MY_ZIP_NAME"
 
-# Test if zip is installed.
-if ! command -v zip &> /dev/null
-then
-    echo "zip could not be found. Maybe "sudo apt-get install zip"?"
-    exit
-fi
-
-# Test is ss_unswizzle.c has been compiled.
-if ! command -v ./ss_unswizzle &> /dev/null
-then
-    echo "ss_unswizzle could not be found. You may try: gcc -o ss_unswizzle ss_unswizzle.c"
-    exit
-fi
-
-# Delete files and directories froms previous runs.
-rm -r "$MY_OUT_ROM_DIR"
-rm "$MY_ZIP_NAME".zip
-rm "$MY_ZIP_NAME".zip_original
-mkdir -p "$MY_OUT_ROM_DIR"
+checkForZip
+checkForCompiledSwizzle
+cleanFilesForReRun $MY_OUT_ROM_DIR, $MY_ZIP_NAME
 
 # Check if s1.bin is available, and copy it as 243-s1.s1.
 if [ ! -f "$MY_RAW_ROMS_DIR"/s1.bin ]; then
@@ -46,21 +32,21 @@ cp "$MY_RAW_ROMS_DIR"/s1.bin "$MY_OUT_ROM_DIR"/243-s1.s1
 
 
 # Sound data
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/243-v1.v1 skip=0 count=$((0x400000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/243-v1.v1 skip=0 count=$((0x400000)) iflag=$IFLAG
 
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/243-v2.v2 skip=$((0x400000)) count=$((0x400000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/243-v2.v2 skip=$((0x400000)) count=$((0x400000)) iflag=$IFLAG
 
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/243-v2.v3 skip=$((0x800000)) count=$((0x400000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/243-v2.v3 skip=$((0x800000)) count=$((0x400000)) iflag=$IFLAG
 
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/243-v2.v4 skip=$((0xC00000)) count=$((0x400000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/243-v2.v4 skip=$((0xC00000)) count=$((0x400000)) iflag=$IFLAG
 
 
 # Z80 code
 cp "$MY_RAW_ROMS_DIR"/m1.bin "$MY_OUT_ROM_DIR"/243-m1.m1
 
 # 68K code
-dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/243-pg1.p1 skip=$((0x0)) count=$((0x100000)) iflag=skip_bytes,count_bytes
-dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/243-pg2.p2 skip=$((0x100000)) count=$((0x400000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/243-pg1.p1 skip=$((0x0)) count=$((0x100000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/243-pg2.p2 skip=$((0x100000)) count=$((0x400000)) iflag=$IFLAG
 
 # Sprites
 # It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2

--- a/goLB2
+++ b/goLB2
@@ -8,10 +8,10 @@
 . ./romExtractionTools.sh
 
 #=========================================================
-MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/The Last Blade 2/Data/rom"
+MY_RAW_ROMS_DIR="$AMAZONGAMEFOLDER"/"The Last Blade 2/Data/rom"
 #=========================================================
 # MY_OUT_ROM_DIR_1 is the temporary output directory for ncommand
-MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_lb2"
+MY_OUT_ROM_DIR_1="$ROMOUTPUTFOLDER"
 #=========================================================
 MY_ZIP_NAME=lastbld2
 ROM_ID="243"

--- a/goLB2
+++ b/goLB2
@@ -28,19 +28,13 @@ cleanFilesForReRun $MY_OUT_ROM_DIR $MY_ZIP_NAME
 if [ ! -f "$MY_RAW_ROMS_DIR"/s1.bin ]; then
     echo "File s1.bin not found in $MY_RAW_ROMS_DIR!"
 fi
-
 cp "$MY_RAW_ROMS_DIR"/s1.bin "$MY_OUT_ROM_DIR"/"$ROM_ID"-s1.s1
-
 
 # Sound data
 dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v1.v1 skip=0 count=$((0x400000)) iflag=$IFLAG
-
 dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v2.v2 skip=$((0x400000)) count=$((0x400000)) iflag=$IFLAG
-
 dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v2.v3 skip=$((0x800000)) count=$((0x400000)) iflag=$IFLAG
-
 dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v2.v4 skip=$((0xC00000)) count=$((0x400000)) iflag=$IFLAG
-
 
 # Z80 code
 cp "$MY_RAW_ROMS_DIR"/m1.bin "$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1
@@ -65,8 +59,4 @@ mv odd_dac "$MY_OUT_ROM_DIR"/"$ROM_ID"-c5.c5
 
 rm even odd
 
-zip -j -r "$MY_ZIP_NAME".zip_original "$MY_OUT_ROM_DIR"
-
 zip -j -r "$MY_ZIP_NAME".zip "$MY_OUT_ROM_DIR"
-
-

--- a/goLB2
+++ b/goLB2
@@ -22,7 +22,7 @@ MY_OUT_ROM_DIR="$MY_OUT_ROM_DIR_1"/"$MY_ZIP_NAME"
 
 checkForZip
 checkForCompiledSwizzle
-cleanFilesForReRun $MY_OUT_ROM_DIR, $MY_ZIP_NAME
+cleanFilesForReRun $MY_OUT_ROM_DIR $MY_ZIP_NAME
 
 # Check if s1.bin is available, and copy it as 243-s1.s1.
 if [ ! -f "$MY_RAW_ROMS_DIR"/s1.bin ]; then

--- a/goLB2
+++ b/goLB2
@@ -14,6 +14,7 @@ MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/The Last Blade 2/Data/rom"
 MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_lb2"
 #=========================================================
 MY_ZIP_NAME=lastbld2
+ROM_ID="243"
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 # Do not edit the path below this line!
 #
@@ -28,25 +29,25 @@ if [ ! -f "$MY_RAW_ROMS_DIR"/s1.bin ]; then
     echo "File s1.bin not found in $MY_RAW_ROMS_DIR!"
 fi
 
-cp "$MY_RAW_ROMS_DIR"/s1.bin "$MY_OUT_ROM_DIR"/243-s1.s1
+cp "$MY_RAW_ROMS_DIR"/s1.bin "$MY_OUT_ROM_DIR"/"$ROM_ID"-s1.s1
 
 
 # Sound data
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/243-v1.v1 skip=0 count=$((0x400000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v1.v1 skip=0 count=$((0x400000)) iflag=$IFLAG
 
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/243-v2.v2 skip=$((0x400000)) count=$((0x400000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v2.v2 skip=$((0x400000)) count=$((0x400000)) iflag=$IFLAG
 
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/243-v2.v3 skip=$((0x800000)) count=$((0x400000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v2.v3 skip=$((0x800000)) count=$((0x400000)) iflag=$IFLAG
 
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/243-v2.v4 skip=$((0xC00000)) count=$((0x400000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v2.v4 skip=$((0xC00000)) count=$((0x400000)) iflag=$IFLAG
 
 
 # Z80 code
-cp "$MY_RAW_ROMS_DIR"/m1.bin "$MY_OUT_ROM_DIR"/243-m1.m1
+cp "$MY_RAW_ROMS_DIR"/m1.bin "$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1
 
 # 68K code
-dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/243-pg1.p1 skip=$((0x0)) count=$((0x100000)) iflag=$IFLAG
-dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/243-pg2.p2 skip=$((0x100000)) count=$((0x400000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-pg1.p1 skip=$((0x0)) count=$((0x100000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-pg2.p2 skip=$((0x100000)) count=$((0x400000)) iflag=$IFLAG
 
 # Sprites
 # It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2
@@ -54,13 +55,13 @@ dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/243-pg2.p2 skip=$((0x100000
 split -b 8388608 even even_d
 split -b 8388608 odd odd_d
 
-mv even_daa "$MY_OUT_ROM_DIR"/243-c2.c2
-mv even_dab "$MY_OUT_ROM_DIR"/243-c4.c4
-mv even_dac "$MY_OUT_ROM_DIR"/243-c6.c6
+mv even_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c2.c2
+mv even_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c4.c4
+mv even_dac "$MY_OUT_ROM_DIR"/"$ROM_ID"-c6.c6
 
-mv odd_daa "$MY_OUT_ROM_DIR"/243-c1.c1
-mv odd_dab "$MY_OUT_ROM_DIR"/243-c3.c3
-mv odd_dac "$MY_OUT_ROM_DIR"/243-c5.c5
+mv odd_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c1.c1
+mv odd_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c3.c3
+mv odd_dac "$MY_OUT_ROM_DIR"/"$ROM_ID"-c5.c5
 
 rm even odd
 

--- a/goLR
+++ b/goLR
@@ -1,16 +1,15 @@
 #!/bin/bash
-# Luca Dal Molin, 2023
-# based on the work of
+#
 # Lionel Cordesses, 2023.
-# Script to build a MAME or FBAlpha romset and also FBNeo romset (extension: .zip) for Last Resort, from the Amazon Prime Gaming game.
+# Script to build a MAME or FBAlpha romset (extension: .zip_original), and also FBNeo romset (extension: .zip) for Last Resort from the Amazon Prime Gaming game.
 
 . ./romExtractionTools.sh
 
 #=========================================================
 MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Last Resort/Data/rom"
 #=========================================================
-# MY_OUT_ROM_DIR_1 is the temporary output directory for ninjamas
-MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_lr"
+# MY_OUT_ROM_DIR_1 is the temporary output directory for ncommand
+MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_lresort"
 #=========================================================
 MY_ZIP_NAME=lresort
 ROM_ID="024"
@@ -21,7 +20,7 @@ MY_OUT_ROM_DIR="$MY_OUT_ROM_DIR_1"/"$MY_ZIP_NAME"
 
 checkForZip
 checkForCompiledSwizzle
-cleanFilesForReRun $MY_OUT_ROM_DIR, $MY_ZIP_NAME
+cleanFilesForReRun $MY_OUT_ROM_DIR $MY_ZIP_NAME
 
 # Check if s2.bin is available, and copy it as 024-s1.s1.
 if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then
@@ -29,35 +28,44 @@ if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then
 fi
 
 cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/"$ROM_ID"-s1.s1
-# Lionel: I add the chmod, as the copy from a Windows filesystem may create an executable file.
-chmod -x "$MY_OUT_ROM_DIR"/"$ROM_ID"-s1.s1
 
 
 # Sound data
 dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v1.v1 skip=0 count=$((0x100000)) iflag=$IFLAG
 dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v2.v2 skip=$((0x100000)) count=$((0x100000)) iflag=$IFLAG
 
-
 # Z80 code
-dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1 skip=$((0x010000)) count=$((0x020000)) iflag=$IFLAG
+# You take the first 64kb of the m1 file, then you take 5888b starting from 128kb and you fill the rest 59648b with FFs
+dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1a skip=$((0x0)) count=$((0x010000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1b skip=$((0x020000)) count=5888 iflag=$IFLAG
+
+# Create the 64KB of 0xff
+dd if=/dev/zero ibs=256 count=233 | tr "\000" "\377" >tmp0xFF.bin
+# Concat 050-m1.m1 and tmp0xFF.bin to create the final 050-m1.m1.
+cat "$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1a "$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1b tmp0xFF.bin >"$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1
+rm "$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1a
+rm "$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1b
+rm tmp0xFF.bin
 
 # 68K code
-dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 skip=$((0x0)) count=$((0x080000)) iflag=$IFLAG
+# Note: the 024-p1.p1 CRC32 is wrong. It is the same issue that I encountered with Ninja Commando and Ghost Pilots.
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 skip=$((0x0)) count=$((0x80000)) iflag=$IFLAG
 
 # Sprites
 # It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2
 ./ss_unswizzle "$MY_RAW_ROMS_DIR"/c1.bin odd even
-split -b 524288 even even_d
-split -b 524288 odd odd_d
+split -b 1048576 even even_d
+split -b 1048576 odd odd_d
 
 mv even_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c2.c2
-dd if=even_dab of="$MY_OUT_ROM_DIR"/"$ROM_ID"-c2.c2 iflag=$IFLAG oflag=append conv=notrunc
-mv even_dac "$MY_OUT_ROM_DIR"/"$ROM_ID"-c4.c4
+mv even_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c4.c4
 
 mv odd_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c1.c1
-dd if=odd_dab of="$MY_OUT_ROM_DIR"/"$ROM_ID"-c1.c1 iflag=$IFLAG oflag=append conv=notrunc
-mv odd_dac "$MY_OUT_ROM_DIR"/"$ROM_ID"-c3.c3
+mv odd_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c3.c3
 
-rm even odd even_dab odd_dab
+rm even odd
+
+# Modification of the 68K file to comply with FBNeo CRC32: replace byte at address 0x115 (value = 02) by (value = 00).
+printf '\x00' | dd of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
 
 zip -j -r "$MY_ZIP_NAME".zip "$MY_OUT_ROM_DIR"

--- a/goLR
+++ b/goLR
@@ -8,10 +8,10 @@
 . ./romExtractionTools.sh
 
 #=========================================================
-MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Last Resort/Data/rom"
+MY_RAW_ROMS_DIR="$AMAZONGAMEFOLDER"/"Last Resort/Data/rom"
 #=========================================================
 # MY_OUT_ROM_DIR_1 is the temporary output directory for ncommand
-MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_lresort"
+MY_OUT_ROM_DIR_1="$ROMOUTPUTFOLDER"
 #=========================================================
 MY_ZIP_NAME=lresort
 ROM_ID="024"

--- a/goLR
+++ b/goLR
@@ -1,5 +1,7 @@
 #!/bin/bash
 #
+# Tomasz Bednarz, 2023
+# based on work by
 # Lionel Cordesses, 2023.
 # Script to build a MAME or FBAlpha romset (extension: .zip_original), and also FBNeo romset (extension: .zip) for Last Resort from the Amazon Prime Gaming game.
 

--- a/goLR
+++ b/goLR
@@ -52,6 +52,8 @@ rm tmp0xFF.bin
 # 68K code
 # Note: the 024-p1.p1 CRC32 is wrong. It is the same issue that I encountered with Ninja Commando and Ghost Pilots.
 dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 skip=$((0x0)) count=$((0x80000)) iflag=$IFLAG
+# Modification of the 68K file to comply with FBNeo CRC32: replace byte at address 0x115 (value = 02) by (value = 00).
+printf '\x00' | dd of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
 
 # Sprites
 # It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2
@@ -66,8 +68,5 @@ mv odd_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c1.c1
 mv odd_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c3.c3
 
 rm even odd
-
-# Modification of the 68K file to comply with FBNeo CRC32: replace byte at address 0x115 (value = 02) by (value = 00).
-printf '\x00' | dd of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
 
 zip -j -r "$MY_ZIP_NAME".zip "$MY_OUT_ROM_DIR"

--- a/goLR
+++ b/goLR
@@ -13,6 +13,7 @@ MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Last Resort/Data/rom"
 MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_lr"
 #=========================================================
 MY_ZIP_NAME=lresort
+ROM_ID="024"
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 # Do not edit the path below this line!
 #
@@ -27,21 +28,21 @@ if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then
     echo "File s2.bin not found in $MY_RAW_ROMS_DIR!"
 fi
 
-cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/024-s1.s1
+cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/"$ROM_ID"-s1.s1
 # Lionel: I add the chmod, as the copy from a Windows filesystem may create an executable file.
-chmod -x "$MY_OUT_ROM_DIR"/024-s1.s1
+chmod -x "$MY_OUT_ROM_DIR"/"$ROM_ID"-s1.s1
 
 
 # Sound data
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/024-v1.v1 skip=0 count=$((0x100000)) iflag=$IFLAG
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/024-v2.v2 skip=$((0x100000)) count=$((0x100000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v1.v1 skip=0 count=$((0x100000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v2.v2 skip=$((0x100000)) count=$((0x100000)) iflag=$IFLAG
 
 
 # Z80 code
-dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/024-m1.m1 skip=$((0x010000)) count=$((0x020000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1 skip=$((0x010000)) count=$((0x020000)) iflag=$IFLAG
 
 # 68K code
-dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/024-p1.p1 skip=$((0x0)) count=$((0x080000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 skip=$((0x0)) count=$((0x080000)) iflag=$IFLAG
 
 # Sprites
 # It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2
@@ -49,13 +50,13 @@ dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/024-p1.p1 skip=$((0x0)) cou
 split -b 524288 even even_d
 split -b 524288 odd odd_d
 
-mv even_daa "$MY_OUT_ROM_DIR"/024-c2.c2
-dd if=even_dab of="$MY_OUT_ROM_DIR"/024-c2.c2 iflag=$IFLAG oflag=append conv=notrunc
-mv even_dac "$MY_OUT_ROM_DIR"/024-c4.c4
+mv even_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c2.c2
+dd if=even_dab of="$MY_OUT_ROM_DIR"/"$ROM_ID"-c2.c2 iflag=$IFLAG oflag=append conv=notrunc
+mv even_dac "$MY_OUT_ROM_DIR"/"$ROM_ID"-c4.c4
 
-mv odd_daa "$MY_OUT_ROM_DIR"/024-c1.c1
-dd if=odd_dab of="$MY_OUT_ROM_DIR"/024-c1.c1 iflag=$IFLAG oflag=append conv=notrunc
-mv odd_dac "$MY_OUT_ROM_DIR"/024-c3.c3
+mv odd_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c1.c1
+dd if=odd_dab of="$MY_OUT_ROM_DIR"/"$ROM_ID"-c1.c1 iflag=$IFLAG oflag=append conv=notrunc
+mv odd_dac "$MY_OUT_ROM_DIR"/"$ROM_ID"-c3.c3
 
 rm even odd even_dab odd_dab
 

--- a/goLR
+++ b/goLR
@@ -4,6 +4,8 @@
 # Lionel Cordesses, 2023.
 # Script to build a MAME or FBAlpha romset and also FBNeo romset (extension: .zip) for Last Resort, from the Amazon Prime Gaming game.
 
+. ./romExtractionTools.sh
+
 #=========================================================
 MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Last Resort/Data/rom"
 #=========================================================
@@ -16,25 +18,9 @@ MY_ZIP_NAME=lresort
 #
 MY_OUT_ROM_DIR="$MY_OUT_ROM_DIR_1"/"$MY_ZIP_NAME"
 
-# Test if zip is installed.
-if ! command -v zip &> /dev/null
-then
-    echo "zip could not be found. Maybe "sudo apt-get install zip"?"
-    exit
-fi
-
-# Test is ss_unswizzle.c has been compiled.
-if ! command -v ./ss_unswizzle &> /dev/null
-then
-    echo "ss_unswizzle could not be found. You may try: gcc -o ss_unswizzle ss_unswizzle.c"
-    exit
-fi
-
-# Delete files and directories froms previous runs.
-rm -r "$MY_OUT_ROM_DIR"
-rm "$MY_ZIP_NAME".zip
-rm "$MY_ZIP_NAME".zip_original
-mkdir -p "$MY_OUT_ROM_DIR"
+checkForZip
+checkForCompiledSwizzle
+cleanFilesForReRun $MY_OUT_ROM_DIR, $MY_ZIP_NAME
 
 # Check if s2.bin is available, and copy it as 024-s1.s1.
 if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then
@@ -47,15 +33,15 @@ chmod -x "$MY_OUT_ROM_DIR"/024-s1.s1
 
 
 # Sound data
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/024-v1.v1 skip=0 count=$((0x100000)) iflag=skip_bytes,count_bytes
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/024-v2.v2 skip=$((0x100000)) count=$((0x100000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/024-v1.v1 skip=0 count=$((0x100000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/024-v2.v2 skip=$((0x100000)) count=$((0x100000)) iflag=$IFLAG
 
 
 # Z80 code
-dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/024-m1.m1 skip=$((0x010000)) count=$((0x020000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/024-m1.m1 skip=$((0x010000)) count=$((0x020000)) iflag=$IFLAG
 
 # 68K code
-dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/024-p1.p1 skip=$((0x0)) count=$((0x080000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/024-p1.p1 skip=$((0x0)) count=$((0x080000)) iflag=$IFLAG
 
 # Sprites
 # It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2
@@ -64,11 +50,11 @@ split -b 524288 even even_d
 split -b 524288 odd odd_d
 
 mv even_daa "$MY_OUT_ROM_DIR"/024-c2.c2
-dd if=even_dab of="$MY_OUT_ROM_DIR"/024-c2.c2 iflag=skip_bytes,count_bytes oflag=append conv=notrunc
+dd if=even_dab of="$MY_OUT_ROM_DIR"/024-c2.c2 iflag=$IFLAG oflag=append conv=notrunc
 mv even_dac "$MY_OUT_ROM_DIR"/024-c4.c4
 
 mv odd_daa "$MY_OUT_ROM_DIR"/024-c1.c1
-dd if=odd_dab of="$MY_OUT_ROM_DIR"/024-c1.c1 iflag=skip_bytes,count_bytes oflag=append conv=notrunc
+dd if=odd_dab of="$MY_OUT_ROM_DIR"/024-c1.c1 iflag=$IFLAG oflag=append conv=notrunc
 mv odd_dac "$MY_OUT_ROM_DIR"/024-c3.c3
 
 rm even odd even_dab odd_dab

--- a/goML
+++ b/goML
@@ -20,7 +20,7 @@ MY_OUT_ROM_DIR="$MY_OUT_ROM_DIR_1"/"$MY_ZIP_NAME"
 
 checkForZip
 checkForCompiledSwizzle
-cleanFilesForReRun $MY_OUT_ROM_DIR, $MY_ZIP_NAME
+cleanFilesForReRun $MY_OUT_ROM_DIR $MY_ZIP_NAME
 
 # Check if s2.bin is available, and copy it as 005-s1.s1.
 if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then

--- a/goML
+++ b/goML
@@ -6,10 +6,10 @@
 . ./romExtractionTools.sh
 
 #=========================================================
-MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Magician Lord/Data/rom"
+MY_RAW_ROMS_DIR="$AMAZONGAMEFOLDER"/"Magician Lord/Data/rom"
 #=========================================================
 # MY_OUT_ROM_DIR_1 is the temporary output directory for ninjamas
-MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_ml"
+MY_OUT_ROM_DIR_1="$ROMOUTPUTFOLDER"
 #=========================================================
 MY_ZIP_NAME=maglord
 ROM_ID="005"

--- a/goML
+++ b/goML
@@ -12,6 +12,7 @@ MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Magician Lord/Data/rom"
 MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_ml"
 #=========================================================
 MY_ZIP_NAME=maglord
+ROM_ID="005"
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 # Do not edit the path below this line!
 #
@@ -26,33 +27,33 @@ if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then
     echo "File s2.bin not found in $MY_RAW_ROMS_DIR!"
 fi
 
-cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/005-s1.s1
+cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/"$ROM_ID"-s1.s1
 
 
 # Sound data
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/005-v1.v1 skip=0 count=$((0x080000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v1.v1 skip=0 count=$((0x080000)) iflag=$IFLAG
 
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/005-v2.v2 skip=$((0x080000)) count=$((0x080000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v2.v2 skip=$((0x080000)) count=$((0x080000)) iflag=$IFLAG
 
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/005-v3.v3 skip=$(( $((0x080000))+$((0x080000)) )) count=$((0x080000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v3.v3 skip=$(( $((0x080000))+$((0x080000)) )) count=$((0x080000)) iflag=$IFLAG
 
 # Z80 code
 # The following line works with FBAlpha, but FBNeo complains about the CRC32. I then tried the same trick that I used for Ninja Commando: half of the size and 0xff padding. It does not work. It is a quarter of the size (64 kB) and 64 kB of 0xff, then the same pattern again (it looks like the memory was read twice).
-#dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/005-m1.m1 skip=$((0x0)) count=$((0x040000)) iflag=$IFLAG
-dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/005-m1.m1b skip=$((0x0)) count=$((0x010000)) iflag=$IFLAG
+#dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1 skip=$((0x0)) count=$((0x040000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1b skip=$((0x0)) count=$((0x010000)) iflag=$IFLAG
 # Create the 64KB of 0xff
 dd if=/dev/zero ibs=1k count=64 | tr "\000" "\377" >tmp0xFF.bin
 # Concat 005-m1.m1 and tmp0xFF.bin to create the final 005-m1.m1.
-cat "$MY_OUT_ROM_DIR"/005-m1.m1b tmp0xFF.bin >"$MY_OUT_ROM_DIR"/005-m1.m1c
-cat "$MY_OUT_ROM_DIR"/005-m1.m1c "$MY_OUT_ROM_DIR"/005-m1.m1c > "$MY_OUT_ROM_DIR"/005-m1.m1
-rm "$MY_OUT_ROM_DIR"/005-m1.m1b
-rm "$MY_OUT_ROM_DIR"/005-m1.m1c
+cat "$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1b tmp0xFF.bin >"$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1c
+cat "$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1c "$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1c > "$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1
+rm "$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1b
+rm "$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1c
 rm tmp0xFF.bin
 
 # 68K code
 # Note: the 005-p1.p1 CRC32 is wrong. It is the same issue that I encountered with Ninja Commando and Ghost Pilots.
-dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/005-pg1.p1 skip=$((0x0)) count=$((0x080000)) iflag=$IFLAG
-#dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/005-p2.sp2 skip=$((0x100000)) count=$((0x200000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-pg1.p1 skip=$((0x0)) count=$((0x080000)) iflag=$IFLAG
+#dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p2.sp2 skip=$((0x100000)) count=$((0x200000)) iflag=$IFLAG
 
 # Sprites
 # It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2
@@ -60,22 +61,22 @@ dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/005-pg1.p1 skip=$((0x0)) co
 split -b 524288 even even_d
 split -b 524288 odd odd_d
 
-mv even_daa "$MY_OUT_ROM_DIR"/005-c2.c2
-mv even_dab "$MY_OUT_ROM_DIR"/005-c4.c4
-mv even_dac "$MY_OUT_ROM_DIR"/005-c6.c6
-#mv even_dad "$MY_OUT_ROM_DIR"/005-c8.c8
+mv even_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c2.c2
+mv even_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c4.c4
+mv even_dac "$MY_OUT_ROM_DIR"/"$ROM_ID"-c6.c6
+#mv even_dad "$MY_OUT_ROM_DIR"/"$ROM_ID"-c8.c8
 
-mv odd_daa "$MY_OUT_ROM_DIR"/005-c1.c1
-mv odd_dab "$MY_OUT_ROM_DIR"/005-c3.c3
-mv odd_dac "$MY_OUT_ROM_DIR"/005-c5.c5
-#mv odd_dad "$MY_OUT_ROM_DIR"/005-c7.c7
+mv odd_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c1.c1
+mv odd_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c3.c3
+mv odd_dac "$MY_OUT_ROM_DIR"/"$ROM_ID"-c5.c5
+#mv odd_dad "$MY_OUT_ROM_DIR"/"$ROM_ID"-c7.c7
 
 rm even odd
 
 zip -j -r "$MY_ZIP_NAME".zip_original "$MY_OUT_ROM_DIR"
 
 # Modification of the first 68K file to comply with FBNeo CRC32: replace byte at address 0x115 (value = 02) by (value = 00).
-printf '\x00' | dd of="$MY_OUT_ROM_DIR"/005-pg1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
+printf '\x00' | dd of="$MY_OUT_ROM_DIR"/"$ROM_ID"-pg1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
 
 zip -j -r "$MY_ZIP_NAME".zip "$MY_OUT_ROM_DIR"
 

--- a/goML
+++ b/goML
@@ -26,20 +26,16 @@ cleanFilesForReRun $MY_OUT_ROM_DIR $MY_ZIP_NAME
 if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then
     echo "File s2.bin not found in $MY_RAW_ROMS_DIR!"
 fi
-
 cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/"$ROM_ID"-s1.s1
-
 
 # Sound data
 dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v1.v1 skip=0 count=$((0x080000)) iflag=$IFLAG
-
 dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v2.v2 skip=$((0x080000)) count=$((0x080000)) iflag=$IFLAG
-
 dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v3.v3 skip=$(( $((0x080000))+$((0x080000)) )) count=$((0x080000)) iflag=$IFLAG
 
 # Z80 code
-# The following line works with FBAlpha, but FBNeo complains about the CRC32. I then tried the same trick that I used for Ninja Commando: half of the size and 0xff padding. It does not work. It is a quarter of the size (64 kB) and 64 kB of 0xff, then the same pattern again (it looks like the memory was read twice).
-#dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1 skip=$((0x0)) count=$((0x040000)) iflag=$IFLAG
+# The following line works with FBAlpha, but FBNeo complains about the CRC32. I then tried the same trick that I used for Ninja Commando: half of the size and 0xff padding.
+# It does not work. It is a quarter of the size (64 kB) and 64 kB of 0xff, then the same pattern again (it looks like the memory was read twice).
 dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1b skip=$((0x0)) count=$((0x010000)) iflag=$IFLAG
 # Create the 64KB of 0xff
 dd if=/dev/zero ibs=1k count=64 | tr "\000" "\377" >tmp0xFF.bin
@@ -53,7 +49,6 @@ rm tmp0xFF.bin
 # 68K code
 # Note: the 005-p1.p1 CRC32 is wrong. It is the same issue that I encountered with Ninja Commando and Ghost Pilots.
 dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-pg1.p1 skip=$((0x0)) count=$((0x080000)) iflag=$IFLAG
-#dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p2.sp2 skip=$((0x100000)) count=$((0x200000)) iflag=$IFLAG
 
 # Sprites
 # It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2
@@ -64,12 +59,10 @@ split -b 524288 odd odd_d
 mv even_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c2.c2
 mv even_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c4.c4
 mv even_dac "$MY_OUT_ROM_DIR"/"$ROM_ID"-c6.c6
-#mv even_dad "$MY_OUT_ROM_DIR"/"$ROM_ID"-c8.c8
 
 mv odd_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c1.c1
 mv odd_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c3.c3
 mv odd_dac "$MY_OUT_ROM_DIR"/"$ROM_ID"-c5.c5
-#mv odd_dad "$MY_OUT_ROM_DIR"/"$ROM_ID"-c7.c7
 
 rm even odd
 
@@ -79,4 +72,3 @@ zip -j -r "$MY_ZIP_NAME".zip_original "$MY_OUT_ROM_DIR"
 printf '\x00' | dd of="$MY_OUT_ROM_DIR"/"$ROM_ID"-pg1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
 
 zip -j -r "$MY_ZIP_NAME".zip "$MY_OUT_ROM_DIR"
-

--- a/goML
+++ b/goML
@@ -2,7 +2,8 @@
 #
 # Lionel Cordesses, 2023.
 # Script to build a MAME or FBAlpha romset (extension: .zip_original), and also FBNeo romset (extension: .zip) for Magician Lord, from the Amazon Prime Gaming game.
-#
+
+. ./romExtractionTools.sh
 
 #=========================================================
 MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Magician Lord/Data/rom"
@@ -16,25 +17,9 @@ MY_ZIP_NAME=maglord
 #
 MY_OUT_ROM_DIR="$MY_OUT_ROM_DIR_1"/"$MY_ZIP_NAME"
 
-# Test if zip is installed.
-if ! command -v zip &> /dev/null
-then
-    echo "zip could not be found. Maybe "sudo apt-get install zip"?"
-    exit
-fi
-
-# Test is ss_unswizzle.c has been compiled.
-if ! command -v ./ss_unswizzle &> /dev/null
-then
-    echo "ss_unswizzle could not be found. You may try: gcc -o ss_unswizzle ss_unswizzle.c"
-    exit
-fi
-
-# Delete files and directories froms previous runs.
-rm -r "$MY_OUT_ROM_DIR"
-rm "$MY_ZIP_NAME".zip
-rm "$MY_ZIP_NAME".zip_original
-mkdir -p "$MY_OUT_ROM_DIR"
+checkForZip
+checkForCompiledSwizzle
+cleanFilesForReRun $MY_OUT_ROM_DIR, $MY_ZIP_NAME
 
 # Check if s2.bin is available, and copy it as 005-s1.s1.
 if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then
@@ -45,16 +30,16 @@ cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/005-s1.s1
 
 
 # Sound data
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/005-v1.v1 skip=0 count=$((0x080000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/005-v1.v1 skip=0 count=$((0x080000)) iflag=$IFLAG
 
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/005-v2.v2 skip=$((0x080000)) count=$((0x080000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/005-v2.v2 skip=$((0x080000)) count=$((0x080000)) iflag=$IFLAG
 
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/005-v3.v3 skip=$(( $((0x080000))+$((0x080000)) )) count=$((0x080000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/005-v3.v3 skip=$(( $((0x080000))+$((0x080000)) )) count=$((0x080000)) iflag=$IFLAG
 
 # Z80 code
 # The following line works with FBAlpha, but FBNeo complains about the CRC32. I then tried the same trick that I used for Ninja Commando: half of the size and 0xff padding. It does not work. It is a quarter of the size (64 kB) and 64 kB of 0xff, then the same pattern again (it looks like the memory was read twice).
-#dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/005-m1.m1 skip=$((0x0)) count=$((0x040000)) iflag=skip_bytes,count_bytes
-dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/005-m1.m1b skip=$((0x0)) count=$((0x010000)) iflag=skip_bytes,count_bytes
+#dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/005-m1.m1 skip=$((0x0)) count=$((0x040000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/005-m1.m1b skip=$((0x0)) count=$((0x010000)) iflag=$IFLAG
 # Create the 64KB of 0xff
 dd if=/dev/zero ibs=1k count=64 | tr "\000" "\377" >tmp0xFF.bin
 # Concat 005-m1.m1 and tmp0xFF.bin to create the final 005-m1.m1.
@@ -66,8 +51,8 @@ rm tmp0xFF.bin
 
 # 68K code
 # Note: the 005-p1.p1 CRC32 is wrong. It is the same issue that I encountered with Ninja Commando and Ghost Pilots.
-dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/005-pg1.p1 skip=$((0x0)) count=$((0x080000)) iflag=skip_bytes,count_bytes
-#dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/005-p2.sp2 skip=$((0x100000)) count=$((0x200000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/005-pg1.p1 skip=$((0x0)) count=$((0x080000)) iflag=$IFLAG
+#dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/005-p2.sp2 skip=$((0x100000)) count=$((0x200000)) iflag=$IFLAG
 
 # Sprites
 # It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2

--- a/goMS4
+++ b/goMS4
@@ -1,1 +1,0 @@
-# Moved to the WIP folder, as it does not work.

--- a/goNCommand
+++ b/goNCommand
@@ -20,7 +20,7 @@ MY_OUT_ROM_DIR="$MY_OUT_ROM_DIR_1"/"$MY_ZIP_NAME"
 
 checkForZip
 checkForCompiledSwizzle
-cleanFilesForReRun $MY_OUT_ROM_DIR, $MY_ZIP_NAME
+cleanFilesForReRun $MY_OUT_ROM_DIR $MY_ZIP_NAME
 
 # Check if s2.bin is available, and copy it as 005-s1.s1.
 if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then

--- a/goNCommand
+++ b/goNCommand
@@ -6,10 +6,10 @@
 . ./romExtractionTools.sh
 
 #=========================================================
-MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/ninja_commando/rom"
+MY_RAW_ROMS_DIR="$AMAZONGAMEFOLDER"/"ninja_commando/rom"
 #=========================================================
 # MY_OUT_ROM_DIR_1 is the temporary output directory for ncommand
-MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_ncommand"
+MY_OUT_ROM_DIR_1="$ROMOUTPUTFOLDER"
 #=========================================================
 MY_ZIP_NAME=ncommand
 ROM_ID="050"

--- a/goNCommand
+++ b/goNCommand
@@ -28,15 +28,12 @@ if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then
 fi
 dd if="$MY_RAW_ROMS_DIR"/s2.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-s1.s1 skip=$((0x0)) count=$((0x020000)) iflag=$IFLAG
 
+# Sound data
 dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v2.v2 skip=$((0x100000)) count=$((0x080000)) iflag=$IFLAG
-
 dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v1.v1 skip=0 count=$((0x100000)) iflag=$IFLAG
-
 dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v2.v2 skip=$((0x100000)) count=$((0x080000)) iflag=$IFLAG
 
-# 050-m1.m1b
 # The first test with 0x20000 works in FBAlpha, but FBNeo complains that the CRC32 is wrong.
-#dd if=/$MY_RAW_ROMS_DIR/m1.bin of=$MY_OUT_ROM_DIR/"$ROM_ID"-m1.m1 skip=$((0x0)) count=$((0x020000)) iflag=$IFLAG
 # I then tried with half of the size for the data, and then 0xFF for the second half. It matches the CRC32.
 dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1b skip=$((0x0)) count=$((0x010000)) iflag=$IFLAG
 # Create the 64KB of 0xff
@@ -46,8 +43,10 @@ cat "$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1b tmp0xFF.bin >"$MY_OUT_ROM_DIR"/"$ROM_ID"-
 rm "$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1b
 rm tmp0xFF.bin
 
+# 68K code
 dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 skip=$((0x0)) count=$((0x100000)) iflag=$IFLAG
-
+# Modification of the 68K file to comply with FBNeo CRC32: replace byte at address 0x115 (value = 02) by (value = 00).
+printf '\x00' | dd of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
 
 # Sprites
 # It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2
@@ -63,11 +62,4 @@ mv odd_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c3.c3
 
 rm even odd
 
-zip -j -r "$MY_ZIP_NAME".zip_original "$MY_OUT_ROM_DIR"
-
-# Modification of the 68K file to comply with FBNeo CRC32: replace byte at address 0x115 (value = 02) by (value = 00).
-printf '\x00' | dd of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
-
 zip -j -r "$MY_ZIP_NAME".zip "$MY_OUT_ROM_DIR"
-
-

--- a/goNCommand
+++ b/goNCommand
@@ -12,6 +12,7 @@ MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/ninja_commando/rom"
 MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_ncommand"
 #=========================================================
 MY_ZIP_NAME=ncommand
+ROM_ID="050"
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 # Do not edit the path below this line!
 #
@@ -25,27 +26,27 @@ cleanFilesForReRun $MY_OUT_ROM_DIR, $MY_ZIP_NAME
 if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then
     echo "File s2.bin not found in $MY_RAW_ROMS_DIR!"
 fi
-dd if="$MY_RAW_ROMS_DIR"/s2.bin of="$MY_OUT_ROM_DIR"/050-s1.s1 skip=$((0x0)) count=$((0x020000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/s2.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-s1.s1 skip=$((0x0)) count=$((0x020000)) iflag=$IFLAG
 
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/050-v2.v2 skip=$((0x100000)) count=$((0x080000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v2.v2 skip=$((0x100000)) count=$((0x080000)) iflag=$IFLAG
 
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/050-v1.v1 skip=0 count=$((0x100000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v1.v1 skip=0 count=$((0x100000)) iflag=$IFLAG
 
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/050-v2.v2 skip=$((0x100000)) count=$((0x080000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v2.v2 skip=$((0x100000)) count=$((0x080000)) iflag=$IFLAG
 
 # 050-m1.m1b
 # The first test with 0x20000 works in FBAlpha, but FBNeo complains that the CRC32 is wrong.
-#dd if=/$MY_RAW_ROMS_DIR/m1.bin of=$MY_OUT_ROM_DIR/050-m1.m1 skip=$((0x0)) count=$((0x020000)) iflag=$IFLAG
+#dd if=/$MY_RAW_ROMS_DIR/m1.bin of=$MY_OUT_ROM_DIR/"$ROM_ID"-m1.m1 skip=$((0x0)) count=$((0x020000)) iflag=$IFLAG
 # I then tried with half of the size for the data, and then 0xFF for the second half. It matches the CRC32.
-dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/050-m1.m1b skip=$((0x0)) count=$((0x010000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1b skip=$((0x0)) count=$((0x010000)) iflag=$IFLAG
 # Create the 64KB of 0xff
 dd if=/dev/zero ibs=1k count=64 | tr "\000" "\377" >tmp0xFF.bin
 # Concat 050-m1.m1 and tmp0xFF.bin to create the final 050-m1.m1.
-cat "$MY_OUT_ROM_DIR"/050-m1.m1b tmp0xFF.bin >"$MY_OUT_ROM_DIR"/050-m1.m1
-rm "$MY_OUT_ROM_DIR"/050-m1.m1b
+cat "$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1b tmp0xFF.bin >"$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1
+rm "$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1b
 rm tmp0xFF.bin
 
-dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/050-p1.p1 skip=$((0x0)) count=$((0x100000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 skip=$((0x0)) count=$((0x100000)) iflag=$IFLAG
 
 
 # Sprites
@@ -54,18 +55,18 @@ dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/050-p1.p1 skip=$((0x0)) cou
 split -b 1048576 even even_d
 split -b 1048576 odd odd_d
 
-mv even_daa "$MY_OUT_ROM_DIR"/050-c2.c2
-mv even_dab "$MY_OUT_ROM_DIR"/050-c4.c4
+mv even_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c2.c2
+mv even_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c4.c4
 
-mv odd_daa "$MY_OUT_ROM_DIR"/050-c1.c1
-mv odd_dab "$MY_OUT_ROM_DIR"/050-c3.c3
+mv odd_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c1.c1
+mv odd_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c3.c3
 
 rm even odd
 
 zip -j -r "$MY_ZIP_NAME".zip_original "$MY_OUT_ROM_DIR"
 
 # Modification of the 68K file to comply with FBNeo CRC32: replace byte at address 0x115 (value = 02) by (value = 00).
-printf '\x00' | dd of="$MY_OUT_ROM_DIR"/050-p1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
+printf '\x00' | dd of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
 
 zip -j -r "$MY_ZIP_NAME".zip "$MY_OUT_ROM_DIR"
 

--- a/goNCommand
+++ b/goNCommand
@@ -3,6 +3,8 @@
 # Lionel Cordesses, 2023.
 # Script to build a MAME or FBAlpha romset (extension: .zip_original), and also FBNeo romset (extension: .zip) for Ninja Commando, from the Amazon Prime Gaming game.
 
+. ./romExtractionTools.sh
+
 #=========================================================
 MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/ninja_commando/rom"
 #=========================================================
@@ -15,43 +17,27 @@ MY_ZIP_NAME=ncommand
 #
 MY_OUT_ROM_DIR="$MY_OUT_ROM_DIR_1"/"$MY_ZIP_NAME"
 
-# Test if zip is installed.
-if ! command -v zip &> /dev/null
-then
-    echo "zip could not be found. Maybe "sudo apt-get install zip"?"
-    exit
-fi
-
-# Test is ss_unswizzle.c has been compiled.
-if ! command -v ./ss_unswizzle &> /dev/null
-then
-    echo "ss_unswizzle could not be found. You may try: gcc -o ss_unswizzle ss_unswizzle.c"
-    exit
-fi
-
-# Delete files and directories froms previous runs.
-rm -r "$MY_OUT_ROM_DIR"
-rm "$MY_ZIP_NAME".zip
-rm "$MY_ZIP_NAME".zip_original
-mkdir -p "$MY_OUT_ROM_DIR"
+checkForZip
+checkForCompiledSwizzle
+cleanFilesForReRun $MY_OUT_ROM_DIR, $MY_ZIP_NAME
 
 # Check if s2.bin is available, and copy it as 005-s1.s1.
 if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then
     echo "File s2.bin not found in $MY_RAW_ROMS_DIR!"
 fi
-dd if="$MY_RAW_ROMS_DIR"/s2.bin of="$MY_OUT_ROM_DIR"/050-s1.s1 skip=$((0x0)) count=$((0x020000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/s2.bin of="$MY_OUT_ROM_DIR"/050-s1.s1 skip=$((0x0)) count=$((0x020000)) iflag=$IFLAG
 
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/050-v2.v2 skip=$((0x100000)) count=$((0x080000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/050-v2.v2 skip=$((0x100000)) count=$((0x080000)) iflag=$IFLAG
 
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/050-v1.v1 skip=0 count=$((0x100000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/050-v1.v1 skip=0 count=$((0x100000)) iflag=$IFLAG
 
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/050-v2.v2 skip=$((0x100000)) count=$((0x080000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/050-v2.v2 skip=$((0x100000)) count=$((0x080000)) iflag=$IFLAG
 
 # 050-m1.m1b
 # The first test with 0x20000 works in FBAlpha, but FBNeo complains that the CRC32 is wrong.
-#dd if=/$MY_RAW_ROMS_DIR/m1.bin of=$MY_OUT_ROM_DIR/050-m1.m1 skip=$((0x0)) count=$((0x020000)) iflag=skip_bytes,count_bytes
+#dd if=/$MY_RAW_ROMS_DIR/m1.bin of=$MY_OUT_ROM_DIR/050-m1.m1 skip=$((0x0)) count=$((0x020000)) iflag=$IFLAG
 # I then tried with half of the size for the data, and then 0xFF for the second half. It matches the CRC32.
-dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/050-m1.m1b skip=$((0x0)) count=$((0x010000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/050-m1.m1b skip=$((0x0)) count=$((0x010000)) iflag=$IFLAG
 # Create the 64KB of 0xff
 dd if=/dev/zero ibs=1k count=64 | tr "\000" "\377" >tmp0xFF.bin
 # Concat 050-m1.m1 and tmp0xFF.bin to create the final 050-m1.m1.
@@ -59,7 +45,7 @@ cat "$MY_OUT_ROM_DIR"/050-m1.m1b tmp0xFF.bin >"$MY_OUT_ROM_DIR"/050-m1.m1
 rm "$MY_OUT_ROM_DIR"/050-m1.m1b
 rm tmp0xFF.bin
 
-dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/050-p1.p1 skip=$((0x0)) count=$((0x100000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/050-p1.p1 skip=$((0x0)) count=$((0x100000)) iflag=$IFLAG
 
 
 # Sprites

--- a/goNM
+++ b/goNM
@@ -20,7 +20,7 @@ MY_OUT_ROM_DIR="$MY_OUT_ROM_DIR_1"/"$MY_ZIP_NAME"
 
 checkForZip
 checkForCompiledSwizzle
-cleanFilesForReRun $MY_OUT_ROM_DIR, $MY_ZIP_NAME
+cleanFilesForReRun $MY_OUT_ROM_DIR $MY_ZIP_NAME
 
 # Check if s2.bin is available, and copy it as 217-s1.s1.
 if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then

--- a/goNM
+++ b/goNM
@@ -3,6 +3,8 @@
 # Lionel Cordesses, 2023.
 # Script to build a MAME or FBAlpha romset (extension: .zip_original), and also FBNeo romset (extension: .zip) for Ninja Master, from the Amazon Prime Gaming game.
 
+. ./romExtractionTools.sh
+
 #=========================================================
 MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Ninja Master's/Data/rom"
 #=========================================================
@@ -15,25 +17,9 @@ MY_ZIP_NAME=ninjamas
 #
 MY_OUT_ROM_DIR="$MY_OUT_ROM_DIR_1"/"$MY_ZIP_NAME"
 
-# Test if zip is installed.
-if ! command -v zip &> /dev/null
-then
-    echo "zip could not be found. Maybe "sudo apt-get install zip"?"
-    exit
-fi
-
-# Test is ss_unswizzle.c has been compiled.
-if ! command -v ./ss_unswizzle &> /dev/null
-then
-    echo "ss_unswizzle could not be found. You may try: gcc -o ss_unswizzle ss_unswizzle.c"
-    exit
-fi
-
-# Delete files and directories froms previous runs.
-rm -r "$MY_OUT_ROM_DIR"
-rm "$MY_ZIP_NAME".zip
-rm "$MY_ZIP_NAME".zip_original
-mkdir -p "$MY_OUT_ROM_DIR"
+checkForZip
+checkForCompiledSwizzle
+cleanFilesForReRun $MY_OUT_ROM_DIR, $MY_ZIP_NAME
 
 # Check if s2.bin is available, and copy it as 217-s1.s1.
 if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then
@@ -44,18 +30,18 @@ cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/217-s1.s1
 
 
 # Sound data
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/217-v1.v1 skip=0 count=$((0x400000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/217-v1.v1 skip=0 count=$((0x400000)) iflag=$IFLAG
 
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/217-v2.v2 skip=$((0x400000)) count=$((0x400000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/217-v2.v2 skip=$((0x400000)) count=$((0x400000)) iflag=$IFLAG
 
 
 # Z80 code
-dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/217-m1.m1 skip=$((0x0)) count=$((0x020000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/217-m1.m1 skip=$((0x0)) count=$((0x020000)) iflag=$IFLAG
 
 # 68K code
 # Note: the 217-p1.p1 CRC32 is wrong. It is the same issue that I encountered with Ninja Commando and Ghost Pilots.
-dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/217-p1.p1 skip=$((0x0)) count=$((0x100000)) iflag=skip_bytes,count_bytes
-dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/217-p2.sp2 skip=$((0x100000)) count=$((0x200000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/217-p1.p1 skip=$((0x0)) count=$((0x100000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/217-p2.sp2 skip=$((0x100000)) count=$((0x200000)) iflag=$IFLAG
 
 # Sprites
 # It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2

--- a/goNM
+++ b/goNM
@@ -26,15 +26,11 @@ cleanFilesForReRun $MY_OUT_ROM_DIR $MY_ZIP_NAME
 if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then
     echo "File s2.bin not found in $MY_RAW_ROMS_DIR!"
 fi
-
 cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/"$ROM_ID"-s1.s1
-
 
 # Sound data
 dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v1.v1 skip=0 count=$((0x400000)) iflag=$IFLAG
-
 dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v2.v2 skip=$((0x400000)) count=$((0x400000)) iflag=$IFLAG
-
 
 # Z80 code
 dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1 skip=$((0x0)) count=$((0x020000)) iflag=$IFLAG
@@ -43,6 +39,8 @@ dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1 skip=$((0x0
 # Note: the 217-p1.p1 CRC32 is wrong. It is the same issue that I encountered with Ninja Commando and Ghost Pilots.
 dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 skip=$((0x0)) count=$((0x100000)) iflag=$IFLAG
 dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p2.sp2 skip=$((0x100000)) count=$((0x200000)) iflag=$IFLAG
+# Modification of the first 68K file to comply with FBNeo CRC32: replace byte at address 0x115 (value = 02) by (value = 00).
+printf '\x00' | dd of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
 
 # Sprites
 # It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2
@@ -62,11 +60,4 @@ mv odd_dad "$MY_OUT_ROM_DIR"/"$ROM_ID"-c7.c7
 
 rm even odd
 
-zip -j -r "$MY_ZIP_NAME".zip_original "$MY_OUT_ROM_DIR"
-
-# Modification of the first 68K file to comply with FBNeo CRC32: replace byte at address 0x115 (value = 02) by (value = 00).
-printf '\x00' | dd of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
-
 zip -j -r "$MY_ZIP_NAME".zip "$MY_OUT_ROM_DIR"
-
-

--- a/goNM
+++ b/goNM
@@ -12,6 +12,7 @@ MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Ninja Master's/Data/rom"
 MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_nm"
 #=========================================================
 MY_ZIP_NAME=ninjamas
+ROM_ID="217"
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 # Do not edit the path below this line!
 #
@@ -26,22 +27,22 @@ if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then
     echo "File s2.bin not found in $MY_RAW_ROMS_DIR!"
 fi
 
-cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/217-s1.s1
+cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/"$ROM_ID"-s1.s1
 
 
 # Sound data
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/217-v1.v1 skip=0 count=$((0x400000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v1.v1 skip=0 count=$((0x400000)) iflag=$IFLAG
 
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/217-v2.v2 skip=$((0x400000)) count=$((0x400000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v2.v2 skip=$((0x400000)) count=$((0x400000)) iflag=$IFLAG
 
 
 # Z80 code
-dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/217-m1.m1 skip=$((0x0)) count=$((0x020000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1 skip=$((0x0)) count=$((0x020000)) iflag=$IFLAG
 
 # 68K code
 # Note: the 217-p1.p1 CRC32 is wrong. It is the same issue that I encountered with Ninja Commando and Ghost Pilots.
-dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/217-p1.p1 skip=$((0x0)) count=$((0x100000)) iflag=$IFLAG
-dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/217-p2.sp2 skip=$((0x100000)) count=$((0x200000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 skip=$((0x0)) count=$((0x100000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p2.sp2 skip=$((0x100000)) count=$((0x200000)) iflag=$IFLAG
 
 # Sprites
 # It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2
@@ -49,22 +50,22 @@ dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/217-p2.sp2 skip=$((0x100000
 split -b 4194304 even even_d
 split -b 4194304 odd odd_d
 
-mv even_daa "$MY_OUT_ROM_DIR"/217-c2.c2
-mv even_dab "$MY_OUT_ROM_DIR"/217-c4.c4
-mv even_dac "$MY_OUT_ROM_DIR"/217-c6.c6
-mv even_dad "$MY_OUT_ROM_DIR"/217-c8.c8
+mv even_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c2.c2
+mv even_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c4.c4
+mv even_dac "$MY_OUT_ROM_DIR"/"$ROM_ID"-c6.c6
+mv even_dad "$MY_OUT_ROM_DIR"/"$ROM_ID"-c8.c8
 
-mv odd_daa "$MY_OUT_ROM_DIR"/217-c1.c1
-mv odd_dab "$MY_OUT_ROM_DIR"/217-c3.c3
-mv odd_dac "$MY_OUT_ROM_DIR"/217-c5.c5
-mv odd_dad "$MY_OUT_ROM_DIR"/217-c7.c7
+mv odd_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c1.c1
+mv odd_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c3.c3
+mv odd_dac "$MY_OUT_ROM_DIR"/"$ROM_ID"-c5.c5
+mv odd_dad "$MY_OUT_ROM_DIR"/"$ROM_ID"-c7.c7
 
 rm even odd
 
 zip -j -r "$MY_ZIP_NAME".zip_original "$MY_OUT_ROM_DIR"
 
 # Modification of the first 68K file to comply with FBNeo CRC32: replace byte at address 0x115 (value = 02) by (value = 00).
-printf '\x00' | dd of="$MY_OUT_ROM_DIR"/217-p1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
+printf '\x00' | dd of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
 
 zip -j -r "$MY_ZIP_NAME".zip "$MY_OUT_ROM_DIR"
 

--- a/goNM
+++ b/goNM
@@ -6,10 +6,10 @@
 . ./romExtractionTools.sh
 
 #=========================================================
-MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Ninja Master's/Data/rom"
+MY_RAW_ROMS_DIR="$AMAZONGAMEFOLDER"/"Ninja Master's/Data/rom"
 #=========================================================
 # MY_OUT_ROM_DIR_1 is the temporary output directory for ninjamas
-MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_nm"
+MY_OUT_ROM_DIR_1="$ROMOUTPUTFOLDER"
 #=========================================================
 MY_ZIP_NAME=ninjamas
 ROM_ID="217"

--- a/goRA
+++ b/goRA
@@ -19,7 +19,7 @@ MY_OUT_ROM_DIR="$MY_OUT_ROM_DIR_1"/"$MY_ZIP_NAME"
 
 checkForZip
 checkForCompiledSwizzle
-cleanFilesForReRun $MY_OUT_ROM_DIR, $MY_ZIP_NAME
+cleanFilesForReRun $MY_OUT_ROM_DIR $MY_ZIP_NAME
 
 # Check if s2.bin is available, and copy it as 032-s1.s1.
 if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then

--- a/goRA
+++ b/goRA
@@ -2,6 +2,7 @@
 #
 # Lionel Cordesses, 2023.
 # Script to build a MAME or FBAlpha romset (extension: .zip_original), and also FBNeo romset (extension: .zip) for Robo Army, from the Amazon Prime Gaming game.
+. ./romExtractionTools.sh
 
 #=========================================================
 MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Robo Army/Data/rom"
@@ -15,25 +16,9 @@ MY_ZIP_NAME=roboarmy
 #
 MY_OUT_ROM_DIR="$MY_OUT_ROM_DIR_1"/"$MY_ZIP_NAME"
 
-# Test if zip is installed.
-if ! command -v zip &> /dev/null
-then
-    echo "zip could not be found. Maybe "sudo apt-get install zip"?"
-    exit
-fi
-
-# Test is ss_unswizzle.c has been compiled.
-if ! command -v ./ss_unswizzle &> /dev/null
-then
-    echo "ss_unswizzle could not be found. You may try: gcc -o ss_unswizzle ss_unswizzle.c"
-    exit
-fi
-
-# Delete files and directories froms previous runs.
-rm -r "$MY_OUT_ROM_DIR"
-rm "$MY_ZIP_NAME".zip
-#rm "$MY_ZIP_NAME".zip_original
-mkdir -p "$MY_OUT_ROM_DIR"
+checkForZip
+checkForCompiledSwizzle
+cleanFilesForReRun $MY_OUT_ROM_DIR, $MY_ZIP_NAME
 
 # Check if s2.bin is available, and copy it as 032-s1.s1.
 if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then
@@ -44,11 +29,11 @@ cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/032-s1.s1
 chmod -x "$MY_OUT_ROM_DIR"/032-s1.s1
 
 # Sound data
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/032-v1.v1 skip=0 count=$((0x100000)) iflag=skip_bytes,count_bytes
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/032-v2.v2 skip=$((0x100000)) count=$((0x100000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/032-v1.v1 skip=0 count=$((0x100000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/032-v2.v2 skip=$((0x100000)) count=$((0x100000)) iflag=$IFLAG
 
 # Z80 code
-dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/032-m1.m1 skip=$((0x0)) count=$((0x020000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/032-m1.m1 skip=$((0x0)) count=$((0x020000)) iflag=$IFLAG
 # Create the 64KB of 0xff
 dd if=/dev/zero ibs=1k count=64 | tr "\000" "\377" >tmp0xFF.bin
 # Concat 050-m1.m1 and tmp0xFF.bin to create the final 050-m1.m1.
@@ -58,7 +43,7 @@ rm tmp0xFF.bin
 
 # 68K code
 # Note: the 032-p1.p1 CRC32 is wrong. It is the same issue that I encountered with Ninja Commando and Ghost Pilots.
-dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/032-p1.p1 skip=$((0x0)) count=$((0x080000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/032-p1.p1 skip=$((0x0)) count=$((0x080000)) iflag=$IFLAG
 #dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/032-p2.sp2 skip=$((0x100000)) count=$((0x200000)) iflag=skip_bytes,count_bytes
 
 # Sprites

--- a/goRA
+++ b/goRA
@@ -35,17 +35,12 @@ dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v2.v2 skip=$((0x1
 
 # Z80 code
 dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1 skip=$((0x0)) count=$((0x020000)) iflag=$IFLAG
-# Create the 64KB of 0xff
-dd if=/dev/zero ibs=1k count=64 | tr "\000" "\377" >tmp0xFF.bin
-# Concat 050-m1.m1 and tmp0xFF.bin to create the final 050-m1.m1.
-#cat "$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1b tmp0xFF.bin >"$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1
-#rm "$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1b
-rm tmp0xFF.bin
 
 # 68K code
 # Note: the 032-p1.p1 CRC32 is wrong. It is the same issue that I encountered with Ninja Commando and Ghost Pilots.
 dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 skip=$((0x0)) count=$((0x080000)) iflag=$IFLAG
-#dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p2.sp2 skip=$((0x100000)) count=$((0x200000)) iflag=skip_bytes,count_bytes
+# Modification of the first 68K file to comply with FBNeo CRC32: replace byte at address 0x115 (value = 02) by (value = 00).
+printf '\x00' | dd of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
 
 # Sprites
 # It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2
@@ -61,12 +56,4 @@ mv odd_dab "$MY_OUT_ROM_DIR"/020-c3.c3
 
 rm even odd
 
-
-#zip -j -r "$MY_ZIP_NAME".zip_original "$MY_OUT_ROM_DIR"
-
-# Modification of the first 68K file to comply with FBNeo CRC32: replace byte at address 0x115 (value = 02) by (value = 00).
-printf '\x00' | dd of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
-
 zip -j -r "$MY_ZIP_NAME".zip "$MY_OUT_ROM_DIR"
-
-

--- a/goRA
+++ b/goRA
@@ -5,10 +5,10 @@
 . ./romExtractionTools.sh
 
 #=========================================================
-MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Robo Army/Data/rom"
+MY_RAW_ROMS_DIR="$AMAZONGAMEFOLDER"/"Robo Army/Data/rom"
 #=========================================================
 # MY_OUT_ROM_DIR_1 is the temporary output directory for ninjamas
-MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_ra"
+MY_OUT_ROM_DIR_1="$ROMOUTPUTFOLDER"
 #=========================================================
 MY_ZIP_NAME=roboarmy
 ROM_ID="032"

--- a/goRA
+++ b/goRA
@@ -11,6 +11,7 @@ MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Robo Army/Data/rom"
 MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_ra"
 #=========================================================
 MY_ZIP_NAME=roboarmy
+ROM_ID="032"
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 # Do not edit the path below this line!
 #
@@ -25,26 +26,26 @@ if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then
     echo "File s2.bin not found in $MY_RAW_ROMS_DIR!"
 fi
 
-cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/032-s1.s1
-chmod -x "$MY_OUT_ROM_DIR"/032-s1.s1
+cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/"$ROM_ID"-s1.s1
+chmod -x "$MY_OUT_ROM_DIR"/"$ROM_ID"-s1.s1
 
 # Sound data
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/032-v1.v1 skip=0 count=$((0x100000)) iflag=$IFLAG
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/032-v2.v2 skip=$((0x100000)) count=$((0x100000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v1.v1 skip=0 count=$((0x100000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v2.v2 skip=$((0x100000)) count=$((0x100000)) iflag=$IFLAG
 
 # Z80 code
-dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/032-m1.m1 skip=$((0x0)) count=$((0x020000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1 skip=$((0x0)) count=$((0x020000)) iflag=$IFLAG
 # Create the 64KB of 0xff
 dd if=/dev/zero ibs=1k count=64 | tr "\000" "\377" >tmp0xFF.bin
 # Concat 050-m1.m1 and tmp0xFF.bin to create the final 050-m1.m1.
-#cat "$MY_OUT_ROM_DIR"/032-m1.m1b tmp0xFF.bin >"$MY_OUT_ROM_DIR"/032-m1.m1
-#rm "$MY_OUT_ROM_DIR"/032-m1.m1b
+#cat "$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1b tmp0xFF.bin >"$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1
+#rm "$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1b
 rm tmp0xFF.bin
 
 # 68K code
 # Note: the 032-p1.p1 CRC32 is wrong. It is the same issue that I encountered with Ninja Commando and Ghost Pilots.
-dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/032-p1.p1 skip=$((0x0)) count=$((0x080000)) iflag=$IFLAG
-#dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/032-p2.sp2 skip=$((0x100000)) count=$((0x200000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 skip=$((0x0)) count=$((0x080000)) iflag=$IFLAG
+#dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p2.sp2 skip=$((0x100000)) count=$((0x200000)) iflag=skip_bytes,count_bytes
 
 # Sprites
 # It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2
@@ -64,7 +65,7 @@ rm even odd
 #zip -j -r "$MY_ZIP_NAME".zip_original "$MY_OUT_ROM_DIR"
 
 # Modification of the first 68K file to comply with FBNeo CRC32: replace byte at address 0x115 (value = 02) by (value = 00).
-printf '\x00' | dd of="$MY_OUT_ROM_DIR"/032-p1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
+printf '\x00' | dd of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
 
 zip -j -r "$MY_ZIP_NAME".zip "$MY_OUT_ROM_DIR"
 

--- a/goSS4_a
+++ b/goSS4_a
@@ -20,7 +20,7 @@ MY_OUT_ROM_DIR="$MY_OUT_ROM_DIR_1"/"$MY_ZIP_NAME"
 
 checkForZip
 checkForCompiledSwizzle
-cleanFilesForReRun $MY_OUT_ROM_DIR, $MY_ZIP_NAME
+cleanFilesForReRun $MY_OUT_ROM_DIR $MY_ZIP_NAME
 
 # Check if s2.bin is available, and copy it as 222-s1.s1.
 if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then

--- a/goSS4_a
+++ b/goSS4_a
@@ -12,6 +12,7 @@ MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Samurai Shodown IV - Amakusa's/Data/
 MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_ss4a"
 #=========================================================
 MY_ZIP_NAME=samsho4
+ROM_ID="222"
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 # Do not edit the path below this line!
 #
@@ -26,22 +27,22 @@ if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then
     echo "File s2.bin not found in $MY_RAW_ROMS_DIR!"
 fi
 
-cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/222-s1.s1
-chmod -x "$MY_OUT_ROM_DIR"/222-s1.s1
+cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/"$ROM_ID"-s1.s1
+chmod -x "$MY_OUT_ROM_DIR"/"$ROM_ID"-s1.s1
 
 # Sound data
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/222-v1.v1 skip=0 count=$((0x400000)) iflag=$IFLAG
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/222-v2.v2 skip=$((0x400000)) count=$((0x400000)) iflag=$IFLAG
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/222-v3.v3 skip=$((0x800000)) count=$((0x200000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v1.v1 skip=0 count=$((0x400000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v2.v2 skip=$((0x400000)) count=$((0x400000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v3.v3 skip=$((0x800000)) count=$((0x200000)) iflag=$IFLAG
 
 # Z80 code
-dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/222-m1.m1 skip=$((0x0)) count=$((0x020000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1 skip=$((0x0)) count=$((0x020000)) iflag=$IFLAG
 
 
 # 68K code
 # Note: the 222-p1.p1 CRC32 is wrong. It is the same issue that I encountered with Ninja Commando and Ghost Pilots.
-dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/222-p1.p1 skip=$((0x0)) count=$((0x100000)) iflag=$IFLAG
-dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/222-p2.sp2 skip=$((0x100000)) count=$((0x400000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 skip=$((0x0)) count=$((0x100000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p2.sp2 skip=$((0x100000)) count=$((0x400000)) iflag=$IFLAG
 
 # Sprites
 # It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2
@@ -49,21 +50,21 @@ dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/222-p2.sp2 skip=$((0x100000
 split -b 4194304 even even
 split -b 4194304 odd odd
 #
-mv evenaa "$MY_OUT_ROM_DIR"/222-c2.c2
-mv evenab "$MY_OUT_ROM_DIR"/222-c4.c4
-mv evenac "$MY_OUT_ROM_DIR"/222-c6.c6
-mv evenad "$MY_OUT_ROM_DIR"/222-c8.c8
+mv evenaa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c2.c2
+mv evenab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c4.c4
+mv evenac "$MY_OUT_ROM_DIR"/"$ROM_ID"-c6.c6
+mv evenad "$MY_OUT_ROM_DIR"/"$ROM_ID"-c8.c8
 # #
-mv oddaa "$MY_OUT_ROM_DIR"/222-c1.c1
-mv oddab "$MY_OUT_ROM_DIR"/222-c3.c3
-mv oddac "$MY_OUT_ROM_DIR"/222-c5.c5
-mv oddad "$MY_OUT_ROM_DIR"/222-c7.c7
+mv oddaa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c1.c1
+mv oddab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c3.c3
+mv oddac "$MY_OUT_ROM_DIR"/"$ROM_ID"-c5.c5
+mv oddad "$MY_OUT_ROM_DIR"/"$ROM_ID"-c7.c7
 rm even odd
 
 #zip -j -r "$MY_ZIP_NAME".zip_original "$MY_OUT_ROM_DIR"
 
 # Modification of the first 68K file to comply with FBNeo CRC32: replace byte at address 0x115 (value = 02) by (value = 00).
-printf '\x00' | dd of="$MY_OUT_ROM_DIR"/222-p1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
+printf '\x00' | dd of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
 
 zip -j -r "$MY_ZIP_NAME".zip "$MY_OUT_ROM_DIR"
 

--- a/goSS4_a
+++ b/goSS4_a
@@ -38,34 +38,29 @@ dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v3.v3 skip=$((0x8
 # Z80 code
 dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1 skip=$((0x0)) count=$((0x020000)) iflag=$IFLAG
 
-
 # 68K code
 # Note: the 222-p1.p1 CRC32 is wrong. It is the same issue that I encountered with Ninja Commando and Ghost Pilots.
 dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 skip=$((0x0)) count=$((0x100000)) iflag=$IFLAG
 dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p2.sp2 skip=$((0x100000)) count=$((0x400000)) iflag=$IFLAG
+# Modification of the first 68K file to comply with FBNeo CRC32: replace byte at address 0x115 (value = 02) by (value = 00).
+printf '\x00' | dd of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
 
 # Sprites
 # It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2
 ./ss_unswizzle "$MY_RAW_ROMS_DIR"/c1.bin odd even
 split -b 4194304 even even
 split -b 4194304 odd odd
-#
+
 mv evenaa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c2.c2
 mv evenab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c4.c4
 mv evenac "$MY_OUT_ROM_DIR"/"$ROM_ID"-c6.c6
 mv evenad "$MY_OUT_ROM_DIR"/"$ROM_ID"-c8.c8
-# #
+
 mv oddaa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c1.c1
 mv oddab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c3.c3
 mv oddac "$MY_OUT_ROM_DIR"/"$ROM_ID"-c5.c5
 mv oddad "$MY_OUT_ROM_DIR"/"$ROM_ID"-c7.c7
+
 rm even odd
 
-#zip -j -r "$MY_ZIP_NAME".zip_original "$MY_OUT_ROM_DIR"
-
-# Modification of the first 68K file to comply with FBNeo CRC32: replace byte at address 0x115 (value = 02) by (value = 00).
-printf '\x00' | dd of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
-
 zip -j -r "$MY_ZIP_NAME".zip "$MY_OUT_ROM_DIR"
-
-

--- a/goSS4_a
+++ b/goSS4_a
@@ -3,6 +3,8 @@
 # Lionel Cordesses, 2023.
 # Script to build a MAME or FBAlpha romset (extension: .zip_original), and also FBNeo romset (extension: .zip) for Samurai Shodown IV, from the Amazon Prime Gaming game.
 
+. /romExtractionTools.sh
+
 #=========================================================
 MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Samurai Shodown IV - Amakusa's/Data/rom"
 #=========================================================
@@ -15,25 +17,9 @@ MY_ZIP_NAME=samsho4
 #
 MY_OUT_ROM_DIR="$MY_OUT_ROM_DIR_1"/"$MY_ZIP_NAME"
 
-# Test if zip is installed.
-if ! command -v zip &> /dev/null
-then
-    echo "zip could not be found. Maybe "sudo apt-get install zip"?"
-    exit
-fi
-
-# Test is ss_unswizzle.c has been compiled.
-if ! command -v ./ss_unswizzle &> /dev/null
-then
-    echo "ss_unswizzle could not be found. You may try: gcc -o ss_unswizzle ss_unswizzle.c"
-    exit
-fi
-
-# Delete files and directories froms previous runs.
-rm -r "$MY_OUT_ROM_DIR"
-rm "$MY_ZIP_NAME".zip
-#rm "$MY_ZIP_NAME".zip_original
-mkdir -p "$MY_OUT_ROM_DIR"
+checkForZip
+checkForCompiledSwizzle
+cleanFilesForReRun $MY_OUT_ROM_DIR, $MY_ZIP_NAME
 
 # Check if s2.bin is available, and copy it as 222-s1.s1.
 if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then
@@ -44,18 +30,18 @@ cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/222-s1.s1
 chmod -x "$MY_OUT_ROM_DIR"/222-s1.s1
 
 # Sound data
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/222-v1.v1 skip=0 count=$((0x400000)) iflag=skip_bytes,count_bytes
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/222-v2.v2 skip=$((0x400000)) count=$((0x400000)) iflag=skip_bytes,count_bytes
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/222-v3.v3 skip=$((0x800000)) count=$((0x200000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/222-v1.v1 skip=0 count=$((0x400000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/222-v2.v2 skip=$((0x400000)) count=$((0x400000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/222-v3.v3 skip=$((0x800000)) count=$((0x200000)) iflag=$IFLAG
 
 # Z80 code
-dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/222-m1.m1 skip=$((0x0)) count=$((0x020000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/222-m1.m1 skip=$((0x0)) count=$((0x020000)) iflag=$IFLAG
 
 
 # 68K code
 # Note: the 222-p1.p1 CRC32 is wrong. It is the same issue that I encountered with Ninja Commando and Ghost Pilots.
-dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/222-p1.p1 skip=$((0x0)) count=$((0x100000)) iflag=skip_bytes,count_bytes
-dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/222-p2.sp2 skip=$((0x100000)) count=$((0x400000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/222-p1.p1 skip=$((0x0)) count=$((0x100000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/222-p2.sp2 skip=$((0x100000)) count=$((0x400000)) iflag=$IFLAG
 
 # Sprites
 # It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2

--- a/goSS4_a
+++ b/goSS4_a
@@ -6,10 +6,10 @@
 . /romExtractionTools.sh
 
 #=========================================================
-MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Samurai Shodown IV - Amakusa's/Data/rom"
+MY_RAW_ROMS_DIR="$AMAZONGAMEFOLDER"/"Samurai Shodown IV - Amakusa's/Data/rom"
 #=========================================================
 # MY_OUT_ROM_DIR_1 is the temporary output directory for ninjamas
-MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_ss4a"
+MY_OUT_ROM_DIR_1="$ROMOUTPUTFOLDER"
 #=========================================================
 MY_ZIP_NAME=samsho4
 ROM_ID="222"

--- a/goSengoku
+++ b/goSengoku
@@ -6,10 +6,10 @@
 . /romExtractionTools.sh
 
 #=========================================================
-MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Sengoku/Data/rom"
+MY_RAW_ROMS_DIR="$AMAZONGAMEFOLDER"/"Sengoku/Data/rom"
 #=========================================================
 # MY_OUT_ROM_DIR_1 is the temporary output directory for ninjamas
-MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_seng"
+MY_OUT_ROM_DIR_1="$ROMOUTPUTFOLDER"
 #=========================================================
 MY_ZIP_NAME=sengoku
 ROM_ID="017"

--- a/goSengoku
+++ b/goSengoku
@@ -30,13 +30,14 @@ fi
 cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/"$ROM_ID"-s1.s1
 chmod -x "$MY_OUT_ROM_DIR"/"$ROM_ID"-s1.s1
 
-
 # Sound data
 dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v1.v1 skip=0 count=$((0x100000)) iflag=$IFLAG
 dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v2.v2 skip=$((0x100000)) count=$((0x100000)) iflag=$IFLAG
 
 # Z80 code
 dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1 skip=$((0x0)) count=$((0x020000)) iflag=$IFLAG
+# Modification of the first 68K file to comply with FBNeo CRC32: replace byte at address 0x115 (value = 02) by (value = 00).
+printf '\x00' | dd of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
 
 # 68K code
 # Note: the 017-p1.p1 CRC32 is wrong. It is the same issue that I encountered with Ninja Commando and Ghost Pilots.
@@ -57,11 +58,4 @@ mv odd_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c3.c3
 
 rm even odd
 
-#zip -j -r "$MY_ZIP_NAME".zip_original "$MY_OUT_ROM_DIR"
-
-# Modification of the first 68K file to comply with FBNeo CRC32: replace byte at address 0x115 (value = 02) by (value = 00).
-printf '\x00' | dd of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
-
 zip -j -r "$MY_ZIP_NAME".zip "$MY_OUT_ROM_DIR"
-
-

--- a/goSengoku
+++ b/goSengoku
@@ -3,6 +3,8 @@
 # Lionel Cordesses, 2023.
 # Script to build a MAME or FBAlpha romset (extension: .zip_original), and also FBNeo romset (extension: .zip) for Sengoku, from the Amazon Prime Gaming game.
 
+. /romExtractionTools.sh
+
 #=========================================================
 MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Sengoku/Data/rom"
 #=========================================================
@@ -15,25 +17,9 @@ MY_ZIP_NAME=sengoku
 #
 MY_OUT_ROM_DIR="$MY_OUT_ROM_DIR_1"/"$MY_ZIP_NAME"
 
-# Test if zip is installed.
-if ! command -v zip &> /dev/null
-then
-    echo "zip could not be found. Maybe "sudo apt-get install zip"?"
-    exit
-fi
-
-# Test is ss_unswizzle.c has been compiled.
-if ! command -v ./ss_unswizzle &> /dev/null
-then
-    echo "ss_unswizzle could not be found. You may try: gcc -o ss_unswizzle ss_unswizzle.c"
-    exit
-fi
-
-# Delete files and directories froms previous runs.
-rm -r "$MY_OUT_ROM_DIR"
-rm "$MY_ZIP_NAME".zip
-rm "$MY_ZIP_NAME".zip_original
-mkdir -p "$MY_OUT_ROM_DIR"
+checkForZip
+checkForCompiledSwizzle
+cleanFilesForReRun $MY_OUT_ROM_DIR, $MY_ZIP_NAME
 
 # Check if s2.bin is available, and copy it as 017-s1.s1.
 if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then
@@ -45,16 +31,16 @@ chmod -x "$MY_OUT_ROM_DIR"/017-s1.s1
 
 
 # Sound data
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/017-v1.v1 skip=0 count=$((0x100000)) iflag=skip_bytes,count_bytes
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/017-v2.v2 skip=$((0x100000)) count=$((0x100000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/017-v1.v1 skip=0 count=$((0x100000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/017-v2.v2 skip=$((0x100000)) count=$((0x100000)) iflag=$IFLAG
 
 # Z80 code
-dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/017-m1.m1 skip=$((0x0)) count=$((0x020000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/017-m1.m1 skip=$((0x0)) count=$((0x020000)) iflag=$IFLAG
 
 # 68K code
 # Note: the 017-p1.p1 CRC32 is wrong. It is the same issue that I encountered with Ninja Commando and Ghost Pilots.
-dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/017-p1.p1 skip=$((0x0)) count=$((0x080000)) iflag=skip_bytes,count_bytes
-dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/017-p2.p2 skip=$((0x080000)) count=$((0x020000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/017-p1.p1 skip=$((0x0)) count=$((0x080000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/017-p2.p2 skip=$((0x080000)) count=$((0x020000)) iflag=$IFLAG
 
 # Sprites
 # It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2

--- a/goSengoku
+++ b/goSengoku
@@ -12,6 +12,7 @@ MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Sengoku/Data/rom"
 MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_seng"
 #=========================================================
 MY_ZIP_NAME=sengoku
+ROM_ID="017"
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 # Do not edit the path below this line!
 #
@@ -26,21 +27,21 @@ if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then
     echo "File s2.bin not found in $MY_RAW_ROMS_DIR!"
 fi
 
-cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/017-s1.s1
-chmod -x "$MY_OUT_ROM_DIR"/017-s1.s1
+cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/"$ROM_ID"-s1.s1
+chmod -x "$MY_OUT_ROM_DIR"/"$ROM_ID"-s1.s1
 
 
 # Sound data
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/017-v1.v1 skip=0 count=$((0x100000)) iflag=$IFLAG
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/017-v2.v2 skip=$((0x100000)) count=$((0x100000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v1.v1 skip=0 count=$((0x100000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v2.v2 skip=$((0x100000)) count=$((0x100000)) iflag=$IFLAG
 
 # Z80 code
-dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/017-m1.m1 skip=$((0x0)) count=$((0x020000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1 skip=$((0x0)) count=$((0x020000)) iflag=$IFLAG
 
 # 68K code
 # Note: the 017-p1.p1 CRC32 is wrong. It is the same issue that I encountered with Ninja Commando and Ghost Pilots.
-dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/017-p1.p1 skip=$((0x0)) count=$((0x080000)) iflag=$IFLAG
-dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/017-p2.p2 skip=$((0x080000)) count=$((0x020000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 skip=$((0x0)) count=$((0x080000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p2.p2 skip=$((0x080000)) count=$((0x020000)) iflag=$IFLAG
 
 # Sprites
 # It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2
@@ -48,18 +49,18 @@ dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/017-p2.p2 skip=$((0x080000)
 split -b $((0x100000)) even even_d
 split -b $((0x100000)) odd odd_d
 
-mv even_daa "$MY_OUT_ROM_DIR"/017-c2.c2
-mv even_dab "$MY_OUT_ROM_DIR"/017-c4.c4
+mv even_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c2.c2
+mv even_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c4.c4
 
-mv odd_daa "$MY_OUT_ROM_DIR"/017-c1.c1
-mv odd_dab "$MY_OUT_ROM_DIR"/017-c3.c3
+mv odd_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c1.c1
+mv odd_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c3.c3
 
 rm even odd
 
 #zip -j -r "$MY_ZIP_NAME".zip_original "$MY_OUT_ROM_DIR"
 
 # Modification of the first 68K file to comply with FBNeo CRC32: replace byte at address 0x115 (value = 02) by (value = 00).
-printf '\x00' | dd of="$MY_OUT_ROM_DIR"/017-p1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
+printf '\x00' | dd of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
 
 zip -j -r "$MY_ZIP_NAME".zip "$MY_OUT_ROM_DIR"
 

--- a/goSengoku
+++ b/goSengoku
@@ -20,7 +20,7 @@ MY_OUT_ROM_DIR="$MY_OUT_ROM_DIR_1"/"$MY_ZIP_NAME"
 
 checkForZip
 checkForCompiledSwizzle
-cleanFilesForReRun $MY_OUT_ROM_DIR, $MY_ZIP_NAME
+cleanFilesForReRun $MY_OUT_ROM_DIR $MY_ZIP_NAME
 
 # Check if s2.bin is available, and copy it as 017-s1.s1.
 if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then

--- a/goSuperS
+++ b/goSuperS
@@ -34,17 +34,13 @@ dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v1.v1 skip=0 coun
 
 # Z80 code
 dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1 skip=$((0x0)) count=$((0x020000)) iflag=$IFLAG
-# Create the 64KB of 0xff
-dd if=/dev/zero ibs=1k count=64 | tr "\000" "\377" >tmp0xFF.bin
-# Concat 050-m1.m1 and tmp0xFF.bin to create the final 050-m1.m1.
-#cat "$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1b tmp0xFF.bin >"$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1
-rm "$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1b
-rm tmp0xFF.bin
 
 # 68K code
 # Note: the 052-p1.p1 CRC32 is wrong. It is the same issue that I encountered with Ninja Commando and Ghost Pilots.
 dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 skip=$((0x0)) count=$((0x080000)) iflag=$IFLAG
-#dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p2.sp2 skip=$((0x100000)) count=$((0x200000)) iflag=$IFLAG
+# Modification of the first 68K file to comply with FBNeo CRC32: replace byte at address 0x115 (value = 02) by (value = 00).
+printf '\x00' | dd of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
+
 
 # Sprites
 # It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2
@@ -56,12 +52,4 @@ cat odd1 odd3 >"$MY_OUT_ROM_DIR"/"$ROM_ID"-c1.c1
 cat even1 even3 >"$MY_OUT_ROM_DIR"/"$ROM_ID"-c2.c2
 rm odd1 odd3 even1 even3 provi_c1.bin provi_c3.bin
 
-
-#zip -j -r "$MY_ZIP_NAME".zip_original "$MY_OUT_ROM_DIR"
-
-# Modification of the first 68K file to comply with FBNeo CRC32: replace byte at address 0x115 (value = 02) by (value = 00).
-printf '\x00' | dd of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
-
 zip -j -r "$MY_ZIP_NAME".zip "$MY_OUT_ROM_DIR"
-
-

--- a/goSuperS
+++ b/goSuperS
@@ -11,6 +11,7 @@ MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Super Sidekicks/Data/rom"
 MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_ss"
 #=========================================================
 MY_ZIP_NAME=ssideki
+ROM_ID="052"
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 # Do not edit the path below this line!
 #
@@ -25,25 +26,25 @@ if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then
     echo "File s2.bin not found in $MY_RAW_ROMS_DIR!"
 fi
 
-cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/052-s1.s1
-chmod -x "$MY_OUT_ROM_DIR"/052-s1.s1
+cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/"$ROM_ID"-s1.s1
+chmod -x "$MY_OUT_ROM_DIR"/"$ROM_ID"-s1.s1
 
 # Sound data
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/052-v1.v1 skip=0 count=$((0x200000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v1.v1 skip=0 count=$((0x200000)) iflag=$IFLAG
 
 # Z80 code
-dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/052-m1.m1 skip=$((0x0)) count=$((0x020000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1 skip=$((0x0)) count=$((0x020000)) iflag=$IFLAG
 # Create the 64KB of 0xff
 dd if=/dev/zero ibs=1k count=64 | tr "\000" "\377" >tmp0xFF.bin
 # Concat 050-m1.m1 and tmp0xFF.bin to create the final 050-m1.m1.
-#cat "$MY_OUT_ROM_DIR"/052-m1.m1b tmp0xFF.bin >"$MY_OUT_ROM_DIR"/052-m1.m1
-rm "$MY_OUT_ROM_DIR"/052-m1.m1b
+#cat "$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1b tmp0xFF.bin >"$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1
+rm "$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1b
 rm tmp0xFF.bin
 
 # 68K code
 # Note: the 052-p1.p1 CRC32 is wrong. It is the same issue that I encountered with Ninja Commando and Ghost Pilots.
-dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/052-p1.p1 skip=$((0x0)) count=$((0x080000)) iflag=$IFLAG
-#dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/052-p2.sp2 skip=$((0x100000)) count=$((0x200000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 skip=$((0x0)) count=$((0x080000)) iflag=$IFLAG
+#dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p2.sp2 skip=$((0x100000)) count=$((0x200000)) iflag=$IFLAG
 
 # Sprites
 # It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2
@@ -51,15 +52,15 @@ dd if="$MY_RAW_ROMS_DIR"/c1.bin of=provi_c1.bin skip=0 count=$(($((0x200000))+$(
 dd if="$MY_RAW_ROMS_DIR"/c1.bin of=provi_c3.bin skip=$(($((0x200000))+$((0x200000)))) count=$(($((0x200000))+$((0x000000)))) iflag=$IFLAG
 ./ss_unswizzle provi_c1.bin odd1 even1
 ./ss_unswizzle provi_c3.bin odd3 even3
-cat odd1 odd3 >"$MY_OUT_ROM_DIR"/052-c1.c1
-cat even1 even3 >"$MY_OUT_ROM_DIR"/052-c2.c2
+cat odd1 odd3 >"$MY_OUT_ROM_DIR"/"$ROM_ID"-c1.c1
+cat even1 even3 >"$MY_OUT_ROM_DIR"/"$ROM_ID"-c2.c2
 rm odd1 odd3 even1 even3 provi_c1.bin provi_c3.bin
 
 
 #zip -j -r "$MY_ZIP_NAME".zip_original "$MY_OUT_ROM_DIR"
 
 # Modification of the first 68K file to comply with FBNeo CRC32: replace byte at address 0x115 (value = 02) by (value = 00).
-printf '\x00' | dd of="$MY_OUT_ROM_DIR"/052-p1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
+printf '\x00' | dd of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 bs=1 seek=$((0x115)) count=1 conv=notrunc
 
 zip -j -r "$MY_ZIP_NAME".zip "$MY_OUT_ROM_DIR"
 

--- a/goSuperS
+++ b/goSuperS
@@ -5,10 +5,10 @@
 . ./romExtractionTools.sh
 
 #=========================================================
-MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Super Sidekicks/Data/rom"
+MY_RAW_ROMS_DIR="$AMAZONGAMEFOLDER"/"Super Sidekicks/Data/rom"
 #=========================================================
 # MY_OUT_ROM_DIR_1 is the temporary output directory for ninjamas
-MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_ss"
+MY_OUT_ROM_DIR_1="$ROMOUTPUTFOLDER"
 #=========================================================
 MY_ZIP_NAME=ssideki
 ROM_ID="052"
@@ -44,8 +44,8 @@ printf '\x00' | dd of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 bs=1 seek=$((0x115)) cou
 
 # Sprites
 # It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2
-dd if="$MY_RAW_ROMS_DIR"/c1.bin of=provi_c1.bin skip=0 count=$(($((0x200000))+$((0x000000)))) iflag=$IFLAG
-dd if="$MY_RAW_ROMS_DIR"/c1.bin of=provi_c3.bin skip=$(($((0x200000))+$((0x200000)))) count=$(($((0x200000))+$((0x000000)))) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/c1.bin of=provi_c1.bin skip=0 count=$((0x200000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/c1.bin of=provi_c3.bin skip=$(($((0x200000))+$((0x200000)))) count=$((0x200000)) iflag=$IFLAG
 ./ss_unswizzle provi_c1.bin odd1 even1
 ./ss_unswizzle provi_c3.bin odd3 even3
 cat odd1 odd3 >"$MY_OUT_ROM_DIR"/"$ROM_ID"-c1.c1

--- a/goSuperS
+++ b/goSuperS
@@ -19,7 +19,7 @@ MY_OUT_ROM_DIR="$MY_OUT_ROM_DIR_1"/"$MY_ZIP_NAME"
 
 checkForZip
 checkForCompiledSwizzle
-cleanFilesForReRun $MY_OUT_ROM_DIR, $MY_ZIP_NAME
+cleanFilesForReRun $MY_OUT_ROM_DIR $MY_ZIP_NAME
 
 # Check if s2.bin is available, and copy it as 052-s1.s1.
 if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then

--- a/goSuperS
+++ b/goSuperS
@@ -2,6 +2,7 @@
 #
 # Lionel Cordesses, 2023.
 # Script to build a MAME or FBAlpha romset (extension: .zip_original), and also FBNeo romset (extension: .zip) for Super Sidekicks, from the Amazon Prime Gaming game.
+. ./romExtractionTools.sh
 
 #=========================================================
 MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Super Sidekicks/Data/rom"
@@ -15,25 +16,9 @@ MY_ZIP_NAME=ssideki
 #
 MY_OUT_ROM_DIR="$MY_OUT_ROM_DIR_1"/"$MY_ZIP_NAME"
 
-# Test if zip is installed.
-if ! command -v zip &> /dev/null
-then
-    echo "zip could not be found. Maybe "sudo apt-get install zip"?"
-    exit
-fi
-
-# Test is ss_unswizzle.c has been compiled.
-if ! command -v ./ss_unswizzle &> /dev/null
-then
-    echo "ss_unswizzle could not be found. You may try: gcc -o ss_unswizzle ss_unswizzle.c"
-    exit
-fi
-
-# Delete files and directories froms previous runs.
-rm -r "$MY_OUT_ROM_DIR"
-rm "$MY_ZIP_NAME".zip
-#rm "$MY_ZIP_NAME".zip_original
-mkdir -p "$MY_OUT_ROM_DIR"
+checkForZip
+checkForCompiledSwizzle
+cleanFilesForReRun $MY_OUT_ROM_DIR, $MY_ZIP_NAME
 
 # Check if s2.bin is available, and copy it as 052-s1.s1.
 if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then
@@ -44,10 +29,10 @@ cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/052-s1.s1
 chmod -x "$MY_OUT_ROM_DIR"/052-s1.s1
 
 # Sound data
-dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/052-v1.v1 skip=0 count=$((0x200000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/052-v1.v1 skip=0 count=$((0x200000)) iflag=$IFLAG
 
 # Z80 code
-dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/052-m1.m1 skip=$((0x0)) count=$((0x020000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/052-m1.m1 skip=$((0x0)) count=$((0x020000)) iflag=$IFLAG
 # Create the 64KB of 0xff
 dd if=/dev/zero ibs=1k count=64 | tr "\000" "\377" >tmp0xFF.bin
 # Concat 050-m1.m1 and tmp0xFF.bin to create the final 050-m1.m1.
@@ -57,13 +42,13 @@ rm tmp0xFF.bin
 
 # 68K code
 # Note: the 052-p1.p1 CRC32 is wrong. It is the same issue that I encountered with Ninja Commando and Ghost Pilots.
-dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/052-p1.p1 skip=$((0x0)) count=$((0x080000)) iflag=skip_bytes,count_bytes
-#dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/052-p2.sp2 skip=$((0x100000)) count=$((0x200000)) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/052-p1.p1 skip=$((0x0)) count=$((0x080000)) iflag=$IFLAG
+#dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/052-p2.sp2 skip=$((0x100000)) count=$((0x200000)) iflag=$IFLAG
 
 # Sprites
 # It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2
-dd if="$MY_RAW_ROMS_DIR"/c1.bin of=provi_c1.bin skip=0 count=$(($((0x200000))+$((0x000000)))) iflag=skip_bytes,count_bytes
-dd if="$MY_RAW_ROMS_DIR"/c1.bin of=provi_c3.bin skip=$(($((0x200000))+$((0x200000)))) count=$(($((0x200000))+$((0x000000)))) iflag=skip_bytes,count_bytes
+dd if="$MY_RAW_ROMS_DIR"/c1.bin of=provi_c1.bin skip=0 count=$(($((0x200000))+$((0x000000)))) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/c1.bin of=provi_c3.bin skip=$(($((0x200000))+$((0x200000)))) count=$(($((0x200000))+$((0x000000)))) iflag=$IFLAG
 ./ss_unswizzle provi_c1.bin odd1 even1
 ./ss_unswizzle provi_c3.bin odd3 even3
 cat odd1 odd3 >"$MY_OUT_ROM_DIR"/052-c1.c1

--- a/goTH
+++ b/goTH
@@ -8,10 +8,10 @@
 . ./romExtractionTools.sh
 
 #=========================================================
-MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Top Hunter - Roddy & Cathy/Data/rom"
+MY_RAW_ROMS_DIR="$AMAZONGAMEFOLDER"/"Top Hunter - Roddy & Cathy/Data/rom"
 #=========================================================
 # MY_OUT_ROM_DIR_1 is the temporary output directory for ncommand
-MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_tophuntr"
+MY_OUT_ROM_DIR_1="$ROMOUTPUTFOLDER"
 #=========================================================
 MY_ZIP_NAME="tophuntr"
 ROM_ID="046"

--- a/goTH
+++ b/goTH
@@ -1,0 +1,64 @@
+#!/bin/bash
+#
+# Tomasz Bednarz, 2023
+# based on work by
+# Lionel Cordesses, 2023.
+# Script to build a MAME or FBAlpha romset (extension: .zip_original), and also FBNeo romset (extension: .zip) for Top Hunter from the Amazon Prime Gaming game.
+
+. ./romExtractionTools.sh
+
+#=========================================================
+MY_RAW_ROMS_DIR="/home/lionel2/provi/amazon/Top Hunter - Roddy & Cathy/Data/rom"
+#=========================================================
+# MY_OUT_ROM_DIR_1 is the temporary output directory for ncommand
+MY_OUT_ROM_DIR_1="/home/lionel2/provi/lionel_tophuntr"
+#=========================================================
+MY_ZIP_NAME="tophuntr"
+ROM_ID="046"
+#++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+# Do not edit the path below this line!
+#
+MY_OUT_ROM_DIR="$MY_OUT_ROM_DIR_1"/"$MY_ZIP_NAME"
+
+checkForZip
+checkForCompiledSwizzle
+cleanFilesForReRun $MY_OUT_ROM_DIR $MY_ZIP_NAME
+
+# Check if s2.bin is available, and copy it as ROM_ID-s1.s1.
+if [ ! -f "$MY_RAW_ROMS_DIR"/s2.bin ]; then
+    echo "File s2.bin not found in $MY_RAW_ROMS_DIR!"
+fi
+cp "$MY_RAW_ROMS_DIR"/s2.bin "$MY_OUT_ROM_DIR"/"$ROM_ID"-s1.s1
+
+# Sound data
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v1.v1 skip=$((0x0)) count=$((0x100000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v2.v2 skip=$((0x100000)) count=$((0x100000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v3.v3 skip=$((0x200000)) count=$((0x100000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/v1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-v4.v4 skip=$((0x300000)) count=$((0x100000)) iflag=$IFLAG
+
+# Z80 code
+dd if="$MY_RAW_ROMS_DIR"/m1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-m1.m1 skip=$((0x0)) count=$((0x040000)) iflag=$IFLAG
+
+# 68K code
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p1.p1 skip=$((0x0)) count=$((0x100000)) iflag=$IFLAG
+dd if="$MY_RAW_ROMS_DIR"/p1.bin of="$MY_OUT_ROM_DIR"/"$ROM_ID"-p2.sp2 skip=$((0x100000)) count=$((0x100000)) iflag=$IFLAG
+
+# Sprites
+# It relies on the code written in Ack's post at https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2
+./ss_unswizzle "$MY_RAW_ROMS_DIR"/c1.bin odd even
+split -b 1048576 even even_d
+split -b 1048576 odd odd_d
+
+mv even_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c2.c2
+mv even_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c4.c4
+mv even_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c6.c6
+mv even_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c8.c8
+
+mv odd_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c1.c1
+mv odd_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c3.c3
+mv odd_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c5.c5
+mv odd_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c7.c7
+
+rm even odd
+
+zip -j -r "$MY_ZIP_NAME".zip "$MY_OUT_ROM_DIR"

--- a/goTH
+++ b/goTH
@@ -51,13 +51,13 @@ split -b 1048576 odd odd_d
 
 mv even_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c2.c2
 mv even_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c4.c4
-mv even_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c6.c6
-mv even_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c8.c8
+mv even_dac "$MY_OUT_ROM_DIR"/"$ROM_ID"-c6.c6
+mv even_dad "$MY_OUT_ROM_DIR"/"$ROM_ID"-c8.c8
 
 mv odd_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c1.c1
 mv odd_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c3.c3
-mv odd_daa "$MY_OUT_ROM_DIR"/"$ROM_ID"-c5.c5
-mv odd_dab "$MY_OUT_ROM_DIR"/"$ROM_ID"-c7.c7
+mv odd_dac "$MY_OUT_ROM_DIR"/"$ROM_ID"-c5.c5
+mv odd_dad "$MY_OUT_ROM_DIR"/"$ROM_ID"-c7.c7
 
 rm even odd
 

--- a/romExtractionTools.sh
+++ b/romExtractionTools.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# Refactored by Tomasz Bednarz, 2023.
+# Based on
+# Lionel Cordesses, 2023.
+# Set of functions to help build a MAME or FBAlpha romset (extension: .zip_original), and also FBNeo romset (extension: .zip)
+# For games from the Amazon Prime Gaming game.
+
+IFLAG=skip_bytes,count_bytes
+
+# Test if zip is installed.
+function checkForZip() {
+    if ! command -v zip &> /dev/null
+    then
+        echo "zip could not be found. Maybe "sudo apt-get install zip"?"
+        exit
+    fi
+}
+
+# Test is ss_unswizzle.c has been compiled.
+function checkForCompiledSwizzle() {
+    if ! command -v ./ss_unswizzle &> /dev/null
+    then
+        echo "ss_unswizzle could not be found. You may try: gcc -o ss_unswizzle ss_unswizzle.c"
+        exit
+    fi
+}
+
+# Delete files and directories froms previous runs.
+function cleanFilesForReRun() {
+    rm -r "$1"
+    rm "$2".zip
+    rm "$2".zip_original
+    mkdir -p "$1"
+}

--- a/romExtractionTools.sh
+++ b/romExtractionTools.sh
@@ -30,6 +30,5 @@ function checkForCompiledSwizzle() {
 function cleanFilesForReRun() {
     rm -r "$1"
     rm "$2".zip
-    rm "$2".zip_original
     mkdir -p "$1"
 }

--- a/romExtractionTools.sh
+++ b/romExtractionTools.sh
@@ -7,6 +7,8 @@
 # For games from the Amazon Prime Gaming game.
 
 IFLAG=skip_bytes,count_bytes
+AMAZONGAMEFOLDER="/mnt/d/Amazon Games/Library"
+ROMOUTPUTFOLDER="/mnt/d/emu/Kawaks/roms/neogeo"
 
 # Test if zip is installed.
 function checkForZip() {


### PR DESCRIPTION
I've done a couple changes to make extending the scripts easier:
- separated the beginning of each file into a single separate script that is used by all others
- made iflag arguments into a global inside the singular script file
- changed rom ids to a global variable

Take a look if you're OK with those changes.
If not, it's cool.
If you would prefer to modify something, let me know in the comments to the PR.