### PR TITLE
Correct path to Ninja Commando ROM files in goNCommand script

### DIFF
--- a/goNCommand
+++ b/goNCommand
@@ -6,7 +6,7 @@
 . ./romExtractionTools.sh
 
 #=========================================================
-MY_RAW_ROMS_DIR="$AMAZONGAMEFOLDER"/"ninja_commando/rom"
+MY_RAW_ROMS_DIR="$AMAZONGAMEFOLDER"/"Ninja Commando/Data/rom"
 #=========================================================
 # MY_OUT_ROM_DIR_1 is the temporary output directory for ncommand
 MY_OUT_ROM_DIR_1="$ROMOUTPUTFOLDER"


### PR DESCRIPTION
Ninja Command points to an incorrect location when using the Amazon Games folder structure unmodified.  Change this to use the correct, unmodified location.